### PR TITLE
making type bounds for bindOneWay easier to use

### DIFF
--- a/model/src/main/java/jetbrains/jetpad/model/property/PropertyBinding.java
+++ b/model/src/main/java/jetbrains/jetpad/model/property/PropertyBinding.java
@@ -20,7 +20,8 @@ import jetbrains.jetpad.model.event.EventHandler;
 import jetbrains.jetpad.base.Registration;
 
 public class PropertyBinding {
-  public static <ValueT> Registration bindOneWay(final ReadableProperty<ValueT> source, final WritableProperty<ValueT> target) {
+  public static <ValueT> Registration bindOneWay(
+      final ReadableProperty<ValueT> source, final WritableProperty<? super ValueT> target) {
     target.set(source.get());
     return source.addHandler(new EventHandler<PropertyChangeEvent<ValueT>>() {
       @Override


### PR DESCRIPTION
This prevents the client from having to capture an extra type variable if source and target actually don't have the same declared generic type.