### PR TITLE
fixes in SimpleAsync 

### DIFF
--- a/util/base/src/main/java/jetbrains/jetpad/base/SimpleAsync.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/SimpleAsync.java
@@ -83,24 +83,34 @@ public final class SimpleAsync<ItemT> implements Async<ItemT> {
     if (alreadyHandled()) {
       throw new IllegalStateException();
     }
-    for (Handler<? super ItemT> handler : mySuccessHandlers) {
-      handler.handle(item);
-    }
-    clearHandlers();
     mySuccessItem = item;
     mySucceeded = true;
+
+    for (Handler<? super ItemT> handler : mySuccessHandlers) {
+      try {
+        handler.handle(item);
+      } catch (Exception e) {
+        ThrowableHandlers.handle(e);
+      }
+    }
+    clearHandlers();
   }
 
   public void failure(Throwable throwable) {
     if (alreadyHandled()) {
       throw new IllegalStateException();
     }
-    for (Handler<Throwable> handler : myFailureHandlers) {
-      handler.handle(throwable);
-    }
-    clearHandlers();
     myFailureThrowable = throwable;
     myFailed = true;
+
+    for (Handler<Throwable> handler : myFailureHandlers) {
+      try {
+        handler.handle(throwable);
+      } catch (Exception e) {
+        ThrowableHandlers.handle(e);
+      }
+    }
+    clearHandlers();
   }
 
   private void clearHandlers() {
@@ -110,5 +120,13 @@ public final class SimpleAsync<ItemT> implements Async<ItemT> {
 
   private boolean alreadyHandled() {
     return mySucceeded || myFailed;
+  }
+
+  boolean hasSucceeded() {
+    return mySucceeded;
+  }
+
+  boolean hasFailed() {
+    return myFailed;
   }
 }

--- a/util/base/src/test/java/jetbrains/jetpad/base/SimpleAsyncTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/SimpleAsyncTest.java
@@ -1,0 +1,84 @@
+package jetbrains.jetpad.base;
+
+import jetbrains.jetpad.test.BaseTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class SimpleAsyncTest extends BaseTestCase {
+  private SimpleAsync<Void> async = new SimpleAsync<>();
+
+  @Test
+  public void exceptionInSuccessHandler() {
+    async.onSuccess(new Handler<Void>() {
+      @Override
+      public void handle(Void item) {
+        throw new RuntimeException();
+      }
+    });
+    try {
+      async.success(null);
+    } catch (RuntimeException e) {
+    }
+    assertTrue(async.hasSucceeded());
+  }
+
+  @Test
+  public void exceptionInFailureHandler() {
+    async.onFailure(new Handler<Throwable>() {
+      @Override
+      public void handle(Throwable t) {
+        throw new RuntimeException();
+      }
+    });
+    try {
+      async.failure(new Throwable());
+    } catch (RuntimeException e) {
+    }
+    assertTrue(async.hasFailed());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void callSuccessInSuccessHandler() {
+    async.onSuccess(new Handler<Void>() {
+      @Override
+      public void handle(Void item) {
+        async.success(null);
+      }
+    });
+    async.success(null);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void callSuccessInFailureHandler() {
+    async.onFailure(new Handler<Throwable>() {
+      @Override
+      public void handle(Throwable item) {
+        async.success(null);
+      }
+    });
+    async.failure(new Throwable());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void callFailureInSuccessHandler() {
+    async.onSuccess(new Handler<Void>() {
+      @Override
+      public void handle(Void item) {
+        async.failure(null);
+      }
+    });
+    async.success(null);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void callFailureInFailureHandler() {
+    async.onFailure(new Handler<Throwable>() {
+      @Override
+      public void handle(Throwable item) {
+        async.failure(null);
+      }
+    });
+    async.failure(new Throwable());
+  }
+}

--- a/util/base/src/test/java/jetbrains/jetpad/base/SimpleAsyncTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/SimpleAsyncTest.java
@@ -10,12 +10,7 @@ public class SimpleAsyncTest extends BaseTestCase {
 
   @Test
   public void exceptionInSuccessHandler() {
-    async.onSuccess(new Handler<Void>() {
-      @Override
-      public void handle(Void item) {
-        throw new RuntimeException();
-      }
-    });
+    async.onSuccess(throwingHandler());
     try {
       async.success(null);
     } catch (RuntimeException e) {
@@ -25,12 +20,7 @@ public class SimpleAsyncTest extends BaseTestCase {
 
   @Test
   public void exceptionInFailureHandler() {
-    async.onFailure(new Handler<Throwable>() {
-      @Override
-      public void handle(Throwable t) {
-        throw new RuntimeException();
-      }
-    });
+    async.onFailure(this.<Throwable>throwingHandler());
     try {
       async.failure(new Throwable());
     } catch (RuntimeException e) {
@@ -40,45 +30,52 @@ public class SimpleAsyncTest extends BaseTestCase {
 
   @Test(expected = IllegalStateException.class)
   public void callSuccessInSuccessHandler() {
-    async.onSuccess(new Handler<Void>() {
-      @Override
-      public void handle(Void item) {
-        async.success(null);
-      }
-    });
+    async.onSuccess(succeedingHandler(async));
     async.success(null);
   }
 
   @Test(expected = IllegalStateException.class)
   public void callSuccessInFailureHandler() {
-    async.onFailure(new Handler<Throwable>() {
-      @Override
-      public void handle(Throwable item) {
-        async.success(null);
-      }
-    });
+    async.onFailure(this.<Throwable>succeedingHandler(async));
     async.failure(new Throwable());
   }
 
   @Test(expected = IllegalStateException.class)
   public void callFailureInSuccessHandler() {
-    async.onSuccess(new Handler<Void>() {
-      @Override
-      public void handle(Void item) {
-        async.failure(null);
-      }
-    });
+    async.onSuccess(failingHandler(async));
     async.success(null);
   }
 
   @Test(expected = IllegalStateException.class)
   public void callFailureInFailureHandler() {
-    async.onFailure(new Handler<Throwable>() {
-      @Override
-      public void handle(Throwable item) {
-        async.failure(null);
-      }
-    });
+    async.onFailure(this.<Throwable>failingHandler(async));
     async.failure(new Throwable());
+  }
+
+  private <ResultT> Handler<ResultT> throwingHandler() {
+    return new Handler<ResultT>() {
+      @Override
+      public void handle(ResultT item) {
+        throw new RuntimeException();
+      }
+    };
+  }
+
+  private <ResultT> Handler<ResultT> succeedingHandler(final SimpleAsync<Void> async) {
+    return new Handler<ResultT>() {
+      @Override
+      public void handle(ResultT item) {
+        async.success(null);
+      }
+    };
+  }
+
+  private <ResultT> Handler<ResultT> failingHandler(final SimpleAsync<Void> async) {
+    return new Handler<ResultT>() {
+      @Override
+      public void handle(ResultT item) {
+        async.failure(new Throwable());
+      }
+    };
   }
 }


### PR DESCRIPTION
state of async should be changed before calling handlers, handler call should be wrapped in try/catch block