### PR TITLE
memory leak: don't register non-findable mappers. Mapper does not reg…

### DIFF
--- a/mapper/src/main/java/jetbrains/jetpad/mapper/ByTargetIndex.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/ByTargetIndex.java
@@ -28,13 +28,17 @@ public class ByTargetIndex {
 
   public ByTargetIndex(MappingContext ctx) {
     for (Mapper<?, ?> mapper : ctx.getMappers()) {
-      myTargetToMappers.put(mapper.getTarget(), mapper);
+      if (mapper.isFindable()) {
+        myTargetToMappers.put(mapper.getTarget(), mapper);
+      }
     }
 
     myRegistration = ctx.addListener(new MappingContextListener() {
       @Override
       public void onMapperRegistered(Mapper<?, ?> mapper) {
-        myTargetToMappers.put(mapper.getTarget(), mapper);
+        if (mapper.isFindable()) {
+          myTargetToMappers.put(mapper.getTarget(), mapper);
+        }
       }
 
       @Override


### PR DESCRIPTION
memory leak: don't register non-findable mappers. Mapper does not register them, but still sends registered event. We choose to code around this behavior instead of changing mapper's event dispatch.