### PR TITLE
DP-697 Prerequisites for synchronizer which can edit list items directly with hybrid editor

### DIFF
--- a/mapper/src/test/java/jetbrains/jetpad/mapper/MappingContextTest.java
+++ b/mapper/src/test/java/jetbrains/jetpad/mapper/MappingContextTest.java
@@ -15,10 +15,16 @@
  */
 package jetbrains.jetpad.mapper;
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Sets;
 import jetbrains.jetpad.base.Value;
 import jetbrains.jetpad.test.BaseTestCase;
 import org.junit.Test;
 
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class MappingContextTest extends BaseTestCase {
@@ -65,6 +71,53 @@ public class MappingContextTest extends BaseTestCase {
     mapper.detach();
 
     assertTrue(mapperUnregistered.get());
+  }
+
+  @Test
+  public void selectMapper() {
+    final Mapper m1 = new ItemMapper(new Item());
+    final Mapper m2 = new ItemMapper(new Item());
+
+    for (Mapper<?, ?> m : new Mapper[] { m1, m2 }) {
+      m.attach(context);
+    }
+
+    Set<Mapper<?, ?>> selection = context.selectMappers(new Predicate<Mapper<?, ?>>() {
+      @Override
+      public boolean apply(Mapper<?, ?> mapper) {
+        return mapper == m1;
+      }
+    });
+
+    assertEquals(selection, Sets.newHashSet(m1));
+  }
+
+  @Test
+  public void selectMappers() {
+    final Item i1 = new Item();
+    Mapper m1 = new ItemMapper(i1);
+    Mapper n1 = new ItemMapper(i1);
+    Mapper m2 = new ItemMapper(new Item());
+
+    for (Mapper<?, ?> m : new Mapper[] { m1, n1, m2 }) {
+      m.attach(context);
+    }
+
+    Set<Mapper<?, ?>> selection = context.selectMappers(new Predicate<Mapper<?, ?>>() {
+      @Override
+      public boolean apply(Mapper<?, ?> mapper) {
+        return mapper.getSource() == i1;
+      }
+    });
+    assertEquals(selection, Sets.newHashSet(m1, n1));
+  }
+
+  @Test
+  public void notFound() {
+    Mapper m = new ItemMapper(new Item());
+    m.attach(context);
+    Set<Mapper<?, ?>> selection = context.selectMappers(Predicates.<Mapper<?, ?>>alwaysFalse());
+    assertTrue(selection.isEmpty());
   }
 
   private ItemMapper createNonFindableMapper() {

--- a/model/src/test/java/jetbrains/jetpad/model/transform/BasePropsListTestCase.java
+++ b/model/src/test/java/jetbrains/jetpad/model/transform/BasePropsListTestCase.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.model.transform;
+
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ValueProperty;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+
+public abstract class BasePropsListTestCase {
+  protected static final int FILL_SIZE = 8;
+  protected static final int LAST = FILL_SIZE - 1;
+  protected static final int MIDDLE = FILL_SIZE / 2;
+  protected static final ObjectsFactory CREATE_NEW_EACH_TIME = new ObjectsFactory() {
+    @Override
+    public Object create() {
+      return new Object();
+    }
+  };
+  protected static final ObjectsFactory REUSE_NEXT_BUT_ONE = new ObjectsFactory() {
+    private Object myReusable = new Object();
+    private boolean myReuseNextTime = true;
+    @Override
+    public Object create() {
+      Object product = myReuseNextTime ? myReusable : new Object();
+      myReuseNextTime = !myReuseNextTime;
+      return product;
+    }
+  };
+
+  protected ObservableList<Object> from;
+  protected ObservableList<Property<Object>> to;
+  protected List<Object> reference;
+  protected Transformation<ObservableList<Object>, ObservableList<Property<Object>>> transformation;
+
+  @Before
+  public void setup() {
+    initLists();
+  }
+
+  @After
+  public void shutdown() {
+    dispose();
+  }
+
+  public abstract void initLists();
+
+  public abstract void dispose();
+
+  protected void fillFromAndReference(ObjectsFactory factory) {
+    for (int i = 0; i < FILL_SIZE; i++) {
+      Object item = factory.create();
+      from.add(item);
+      reference.add(item);
+    }
+  }
+
+  protected void fillToAndReference(ObjectsFactory factory) {
+    for (int i = 0; i < FILL_SIZE; i++) {
+      Object item = factory.create();
+      to.add(new ValueProperty<>(item));
+      reference.add(item);
+    }
+  }
+
+  protected void fillFrom(ObjectsFactory factory) {
+    for (int i = 0; i < FILL_SIZE; i++) {
+      from.add(factory.create());
+    }
+  }
+
+  protected void verifyListsAgainstReference() {
+    verifyFromAgainstReference();
+    verifyToAgainstReference();
+  }
+
+  protected void verifyFromAgainstReference() {
+    assertEquals(reference.size(), from.size());
+    for (int i = 0; i < reference.size(); i++) {
+      assertEquals(reference.get(i), from.get(i));
+    }
+  }
+
+  protected void verifyToAgainstReference() {
+    assertEquals(reference.size(), to.size());
+    for (int i = 0; i < reference.size(); i++) {
+      assertEquals(reference.get(i), to.get(i).get());
+    }
+  }
+
+  private interface ObjectsFactory {
+    Object create();
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/transform/PreinitializedPropsListTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/transform/PreinitializedPropsListTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.model.transform;
+
+import jetbrains.jetpad.model.collections.list.ObservableArrayList;
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ValueProperty;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+
+public class PreinitializedPropsListTest extends BasePropsListTestCase {
+  @Override
+  public void initLists() {
+    from = new ObservableArrayList<>();
+    to = new ObservableArrayList<>();
+    reference = new ArrayList<>();
+    transformation = Transformers.toPropsListTwoWay().transform(from, to);
+  }
+
+  @Override
+  public void dispose() {
+    transformation.dispose();
+  }
+
+  @Test
+  public void verifyTransformation() {
+    assertTrue(transformation.getSource() == from);
+    assertTrue(transformation.getTarget() == to);
+  }
+
+  @Test
+  public void fillForwardWithUniqueItems() {
+    fillFromAndReference(CREATE_NEW_EACH_TIME);
+    verifyListsAgainstReference();
+  }
+
+  @Test
+  public void fillBackwardWithUniqueItems() {
+    fillToAndReference(CREATE_NEW_EACH_TIME);
+    verifyListsAgainstReference();
+  }
+
+  @Test
+  public void fillForwardWithRepeats() {
+    fillFromAndReference(REUSE_NEXT_BUT_ONE);
+    verifyListsAgainstReference();
+  }
+
+  @Test
+  public void fillBackwardWithRepeats() {
+    fillToAndReference(REUSE_NEXT_BUT_ONE);
+    verifyListsAgainstReference();
+  }
+
+  @Test
+  public void setForward() {
+    testItemsSet(new ItemSetter() {
+      @Override
+      public void doSet(int index, Object newItem) {
+        from.set(index, newItem);
+      }
+      @Override
+      public boolean newPropertyMustBeCreated() {
+        return false;
+      }
+    });
+  }
+
+  @Test
+  public void setBackwardValue() {
+    testItemsSet(new ItemSetter() {
+      @Override
+      public void doSet(int index, Object newItem) {
+        to.get(index).set(newItem);
+      }
+      @Override
+      public boolean newPropertyMustBeCreated() {
+        return false;
+      }
+    });
+  }
+
+  @Test
+  public void setBackwardProperty() {
+    testItemsSet(new ItemSetter() {
+      @Override
+      public void doSet(int index, Object newItem) {
+        to.set(index, new ValueProperty<>(newItem));
+      }
+      @Override
+      public boolean newPropertyMustBeCreated() {
+        return true;
+      }
+    });
+  }
+
+  private void testItemsSet(ItemSetter itemSetter) {
+    fillFrom(REUSE_NEXT_BUT_ONE);
+    // Set first, two adjacent items in the middle (unique and non-unique), and last
+    for (int index : new int[] { 0, MIDDLE, MIDDLE + 1, LAST}) {
+      Property<Object> oldProperty = to.get(index);
+      Object newItem = new Object();
+      itemSetter.doSet(index, newItem);
+      Property<Object> newProperty = to.get(index);
+      if (itemSetter.newPropertyMustBeCreated()) {
+        assertTrue(oldProperty != newProperty);
+      } else {
+        assertTrue(oldProperty == newProperty);
+      }
+      assertEquals(newItem, from.get(index));
+      assertEquals(newItem, newProperty.get());
+    }
+  }
+
+  @Test
+  public void removeForward() {
+    testItemsRemove(new ItemRemover() {
+      @Override
+      public void doRemove(int index) {
+        from.remove(index);
+      }
+    });
+  }
+
+  @Test
+  public void removeBackward() {
+    testItemsRemove(new ItemRemover() {
+      @Override
+      public void doRemove(int index) {
+        to.remove(index);
+      }
+    });
+  }
+
+  private void testItemsRemove(ItemRemover itemRemover) {
+    fillFromAndReference(REUSE_NEXT_BUT_ONE);
+    // Remove last, twice from the middle (unique and non-unique), and first
+    for (int index : new int[] { LAST, MIDDLE, MIDDLE, 0 }) {
+      itemRemover.doRemove(index);
+      reference.remove(index);
+      verifyListsAgainstReference();
+    }
+  }
+
+  @Test
+  public void clearForward() {
+    fillFrom(REUSE_NEXT_BUT_ONE);
+    from.clear();
+    checkBothListsEmpty();
+  }
+
+  @Test
+  public void clearBackward() {
+    fillFrom(REUSE_NEXT_BUT_ONE);
+    to.clear();
+    checkBothListsEmpty();
+  }
+
+  private void checkBothListsEmpty() {
+    assertTrue(from.isEmpty());
+    assertTrue(to.isEmpty());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void addSamePropertyTwice() {
+    Property<Object> prop = new ValueProperty<>(new Object());
+    to.add(prop);
+    to.add(prop);
+  }
+
+  private interface ItemSetter {
+    void doSet(int index, Object newItem);
+    boolean newPropertyMustBeCreated();
+  }
+
+  private interface ItemRemover {
+    void doRemove(int index);
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/transform/PropsListInitializationAndDisposalTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/transform/PropsListInitializationAndDisposalTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.model.transform;
+
+import jetbrains.jetpad.model.collections.list.ObservableArrayList;
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ValueProperty;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static jetbrains.jetpad.model.transform.Transformers.toPropsListTwoWay;
+import static junit.framework.TestCase.assertEquals;
+
+public class PropsListInitializationAndDisposalTest extends BasePropsListTestCase {
+  private boolean myDisposeNeeded = false;
+
+  @Override
+  public void initLists() {
+    from = new ObservableArrayList<>();
+    reference = new ArrayList<>();
+  }
+
+  @Override
+  public void dispose() {
+    if (myDisposeNeeded) {
+      transformation.dispose();
+    }
+  }
+
+  @Test
+  public void useNonemptySourceList() {
+    fillFromAndReference(REUSE_NEXT_BUT_ONE);
+    transformation = toPropsListTwoWay().transform(from);
+    to = transformation.getTarget();
+    verifyListsAgainstReference();
+    myDisposeNeeded = true;
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void useNonemptyTargetList() {
+    to = new ObservableArrayList<>();
+    to.add(new ValueProperty<>(new Object()));
+    try {
+      toPropsListTwoWay().transform(from, to);
+    } finally {
+      myDisposeNeeded = false;
+    }
+  }
+
+  @Test
+  public void addRemoveAfterUnbinding() {
+    fillAndDispose();
+    from.add(new Object());
+    to.remove(LAST);
+    assertEquals(FILL_SIZE + 1, from.size());
+    assertEquals(FILL_SIZE - 1, to.size());
+  }
+
+  @Test
+  public void setForwardAfterUnbinding() {
+    fillAndDispose();
+    Property<Object> oldProperty = to.get(MIDDLE);
+    Object oldItem = oldProperty.get();
+    from.set(MIDDLE, new Object());
+    assertEquals(oldProperty, to.get(MIDDLE));
+    assertEquals(oldItem, to.get(MIDDLE).get());
+  }
+
+  @Test
+  public void setBackwardValueAfterUnbinding() {
+    fillAndDispose();
+    Object oldItem = from.get(MIDDLE);
+    to.get(MIDDLE).set(new Object());
+    assertEquals(oldItem, from.get(MIDDLE));
+  }
+
+  @Test
+  public void setBackwardPropertyAfterUnbinding() {
+    fillAndDispose();
+    Object oldItem = from.get(MIDDLE);
+    to.set(MIDDLE, new ValueProperty<>(new Object()));
+    assertEquals(oldItem, from.get(MIDDLE));
+  }
+
+  private void fillAndDispose() {
+    transformation = toPropsListTwoWay().transform(from);
+    to = transformation.getTarget();
+    fillFrom(REUSE_NEXT_BUT_ONE);
+    transformation.dispose();
+    myDisposeNeeded = false;
+  }
+}


### PR DESCRIPTION
New transformer: two-way between `ObservableList<T>` and `ObservableList<Property<T>>`. This is needed to give list items to hybrid synchronizer which needs `Property<T>`.

Changes in `MappingContext`: getting mappers by some predicate against a mapper. This allows using `Property<T>` as mapper source, and selecting mapper by property value.