### PR TITLE
Use mockito-core instead of mockito-all

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -43,10 +43,23 @@
       </dependency>
 
       <dependency>
+        <!-- To be removed -->
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>hamcrest-core</artifactId>
+            <groupId>org.hamcrest</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/mapper/pom.xml
+++ b/mapper/pom.xml
@@ -30,7 +30,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
     <dependency>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -24,7 +24,7 @@
   <dependencies>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
 
     <dependency>

--- a/util/base/pom.xml
+++ b/util/base/pom.xml
@@ -47,7 +47,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
I originally needed this to make `assertThat` from hamcrest work reliably.
It was later decided to leave the code that used `assertThat` in our project,
but, anyway, are there any reasons not to make this change?