### PR TITLE
DP-697 Prerequisites for editing ObservableList items directly with HybridEditors

### DIFF
--- a/mapper/src/main/java/jetbrains/jetpad/mapper/RoleToPropertyAdapter.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/RoleToPropertyAdapter.java
@@ -1,0 +1,35 @@
+package jetbrains.jetpad.mapper;
+
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.transform.Transformation;
+import jetbrains.jetpad.model.transform.Transformers;
+
+public abstract class RoleToPropertyAdapter<SourceT, TargetT> implements Synchronizer {
+  private final ObservableList<SourceT> mySourceList;
+  private Transformation<ObservableList<SourceT>, ObservableList<Property<SourceT>>> myTransformation;
+  private RoleSynchronizer<Property<SourceT>, TargetT> myRoleSync;
+
+  public RoleToPropertyAdapter(ObservableList<SourceT> sourceList) {
+    mySourceList = sourceList;
+  }
+
+  @Override
+  public void attach(SynchronizerContext ctx) {
+    myTransformation = Transformers.<SourceT>toPropsListTwoWay().transform(mySourceList);
+    myRoleSync = createRoleSynchronizer(myTransformation.getTarget());
+    myRoleSync.attach(ctx);
+  }
+
+  @Override
+  public void detach() {
+    myRoleSync.detach();
+    myTransformation.dispose();
+  }
+
+  public abstract RoleSynchronizer<Property<SourceT>, TargetT> createRoleSynchronizer(ObservableList<Property<SourceT>> propsSourceList);
+
+  public RoleSynchronizer<Property<SourceT>, TargetT> getRoleSynchronizer() {
+    return myRoleSync;
+  }
+}

--- a/mapper/src/test/java/jetbrains/jetpad/mapper/Item.java
+++ b/mapper/src/test/java/jetbrains/jetpad/mapper/Item.java
@@ -47,6 +47,7 @@ class Item {
   public final ObservableList<Item> transformedChildren = new ObservableArrayList<>();
   public final Property<Item> singleChild = new ValueProperty<>();
   public final Property<String> name = new ValueProperty<>();
+  public final ObservableList<Item> observableChildrenForAdapter = new ObservableArrayList<>();
 
   Item() {
   }
@@ -61,6 +62,7 @@ class Item {
         && contentsEqual(observableChildren, item.observableChildren)
         && contentsEqual(children, item.children)
         && contentsEqual(transformedChildren, item.transformedChildren)
-        && contentsEqual(singleChild.get(), item.singleChild.get());
+        && contentsEqual(singleChild.get(), item.singleChild.get())
+        && contentsEqual(observableChildrenForAdapter, item.observableChildrenForAdapter);
   }
 }

--- a/mapper/src/test/java/jetbrains/jetpad/mapper/ItemMapper.java
+++ b/mapper/src/test/java/jetbrains/jetpad/mapper/ItemMapper.java
@@ -15,6 +15,8 @@
  */
 package jetbrains.jetpad.mapper;
 
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import jetbrains.jetpad.model.property.Property;
 import jetbrains.jetpad.model.transform.Transformers;
 
 class ItemMapper extends Mapper<Item, Item> {
@@ -24,6 +26,10 @@ class ItemMapper extends Mapper<Item, Item> {
     super(item, new Item());
   }
 
+  ItemMapper(Item source, Item target) {
+    super(source, target);
+  }
+
   @Override
   protected void registerSynchronizers(SynchronizersConfiguration conf) {
     conf.add(Synchronizers.forObservableRole(this, getSource().observableChildren, getTarget().observableChildren, createMapperFactory()));
@@ -31,6 +37,12 @@ class ItemMapper extends Mapper<Item, Item> {
     conf.add(Synchronizers.forSingleRole(this, getSource().singleChild, getTarget().singleChild, createMapperFactory()));
     conf.add(mySimpleRole = Synchronizers.forSimpleRole(this, getSource().children, getTarget().children, createMapperFactory()));
     conf.add(Synchronizers.forPropsTwoWay(getSource().name, getTarget().name));
+    conf.add(new RoleToPropertyAdapter<Item, Item>(getSource().observableChildrenForAdapter) {
+      @Override
+      public RoleSynchronizer<Property<Item>, Item> createRoleSynchronizer(ObservableList<Property<Item>> propsSourceList) {
+        return Synchronizers.forObservableRole(ItemMapper.this, propsSourceList, getTarget().observableChildrenForAdapter, createPropertyMapperFactory());
+      }
+    });
   }
 
   public void refreshSimpleRole() {
@@ -42,6 +54,21 @@ class ItemMapper extends Mapper<Item, Item> {
       @Override
       public Mapper<? extends Item, ? extends Item> createMapper(Item source) {
         return new ItemMapper(source);
+      }
+    };
+  }
+
+  protected MapperFactory<Property<Item>, Item> createPropertyMapperFactory() {
+    return new MapperFactory<Property<Item>, Item>() {
+      @Override
+      public Mapper<? extends Property<Item>, ? extends Item> createMapper(Property<Item> source) {
+        return new Mapper<Property<Item>, Item>(source, new Item()) {
+          @Override
+          protected void onAttach(MappingContext ctx) {
+            super.onAttach(ctx);
+            createChildList().add(new ItemMapper(getSource().get(), getTarget()));
+          }
+        };
       }
     };
   }

--- a/mapper/src/test/java/jetbrains/jetpad/mapper/MapperTest.java
+++ b/mapper/src/test/java/jetbrains/jetpad/mapper/MapperTest.java
@@ -97,16 +97,32 @@ public class MapperTest extends BaseTestCase {
   }
 
   @Test
+  public void removeItemFromAdapted() {
+    source.observableChildrenForAdapter.remove(0);
+
+    assertMapped();
+  }
+
+  @Test
+  public void addItemToAdapted() {
+    source.observableChildrenForAdapter.add(new Item());
+
+    assertMapped();
+  }
+
+  @Test
   public void rolesAreCleanedOnDetach() {
     assertFalse(target.observableChildren.isEmpty());
     assertFalse(target.children.isEmpty());
     assertFalse(target.transformedChildren.isEmpty());
+    assertFalse(target.observableChildrenForAdapter.isEmpty());
 
     mapper.detachRoot();
 
     assertTrue(target.observableChildren.isEmpty());
     assertTrue(target.children.isEmpty());
     assertTrue(target.transformedChildren.isEmpty());
+    assertTrue(target.observableChildrenForAdapter.isEmpty());
   }
 
   @Test
@@ -187,6 +203,7 @@ public class MapperTest extends BaseTestCase {
       result.observableChildren.add(child);
       result.children.add(child);
       result.transformedChildren.add(child);
+      result.observableChildrenForAdapter.add(child);
     }
 
     return result;

--- a/model/src/main/java/jetbrains/jetpad/model/property/NullSubstitutingProperty.java
+++ b/model/src/main/java/jetbrains/jetpad/model/property/NullSubstitutingProperty.java
@@ -1,0 +1,22 @@
+package jetbrains.jetpad.model.property;
+
+public class NullSubstitutingProperty<ValueT> extends DelegateProperty<ValueT> {
+  private final NullSubstitutionSpec<ValueT> mySpec;
+
+  public NullSubstitutingProperty(Property<ValueT> targetProperty, NullSubstitutionSpec<ValueT> spec) {
+    super(targetProperty);
+    mySpec = spec;
+  }
+
+  @Override
+  public ValueT get() {
+    ValueT val = super.get();
+    return mySpec.isSubstitute(val) ? null : val;
+  }
+
+  @Override
+  public void set(ValueT val) {
+    ValueT valueToSet = val == null ? mySpec.createSubstitute() :  val;
+    super.set(valueToSet);
+  }
+}

--- a/model/src/main/java/jetbrains/jetpad/model/property/NullSubstitutionSpec.java
+++ b/model/src/main/java/jetbrains/jetpad/model/property/NullSubstitutionSpec.java
@@ -1,0 +1,6 @@
+package jetbrains.jetpad.model.property;
+
+public interface NullSubstitutionSpec<ValueT> {
+  ValueT createSubstitute();
+  boolean isSubstitute(ValueT value);
+}

--- a/model/src/test/java/jetbrains/jetpad/model/property/NullSubstitutingPropertyTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/property/NullSubstitutingPropertyTest.java
@@ -1,0 +1,50 @@
+package jetbrains.jetpad.model.property;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NullSubstitutingPropertyTest {
+  private static final String SAMPLE = "abc";
+  private static final String NULL_SUBSTITUTE = "";
+
+  private Property<String> target = new ValueProperty<>();
+  private Property<String> substituting = new NullSubstitutingProperty<>(target, new NullSubstitutionSpec<String>() {
+    @Override
+    public String createSubstitute() {
+      return NULL_SUBSTITUTE;
+    }
+    @Override
+    public boolean isSubstitute(String value) {
+      return NULL_SUBSTITUTE.equals(value);
+    }
+  });
+
+  @Test
+  public void forwardNonNull() {
+    substituting.set(SAMPLE);
+    assertEquals(SAMPLE, substituting.get());
+    assertEquals(SAMPLE, target.get());
+  }
+
+  @Test
+  public void backwardNonNull() {
+    target.set(SAMPLE);
+    assertEquals(SAMPLE, substituting.get());
+    assertEquals(SAMPLE, target.get());
+  }
+
+  @Test
+  public void forwardNull() {
+    substituting.set(null);
+    assertEquals(null, substituting.get());
+    assertEquals(NULL_SUBSTITUTE, target.get());
+  }
+
+  @Test
+  public void backwardSubstitute() {
+    target.set(NULL_SUBSTITUTE);
+    assertEquals(null, substituting.get());
+    assertEquals(NULL_SUBSTITUTE, target.get());
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/transform/BasePropsListTestCase.java
+++ b/model/src/test/java/jetbrains/jetpad/model/transform/BasePropsListTestCase.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.model.transform;
+
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ValueProperty;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+
+public abstract class BasePropsListTestCase {
+  protected static final int FILL_SIZE = 8;
+  protected static final int LAST = FILL_SIZE - 1;
+  protected static final int MIDDLE = FILL_SIZE / 2;
+
+  protected ObservableList<Object> from;
+  protected ObservableList<Property<Object>> to;
+  protected List<Object> reference;
+  protected Transformation<ObservableList<Object>, ObservableList<Property<Object>>> transformation;
+
+  @Before
+  public void setup() {
+    initLists();
+  }
+
+  @After
+  public void shutdown() {
+    dispose();
+  }
+
+  public abstract void initLists();
+
+  public abstract void dispose();
+
+  protected void fillFromAndReference() {
+    for (int i = 0; i < FILL_SIZE; i++) {
+      Object item = new Object();
+      from.add(item);
+      reference.add(item);
+    }
+  }
+
+  protected void fillToAndReference() {
+    for (int i = 0; i < FILL_SIZE; i++) {
+      Object item = new Object();
+      to.add(new ValueProperty<>(item));
+      reference.add(item);
+    }
+  }
+
+  protected void fillFrom() {
+    for (int i = 0; i < FILL_SIZE; i++) {
+      from.add(new Object());
+    }
+  }
+
+  protected void verifyListsAgainstReference() {
+    verifyFromAgainstReference();
+    verifyToAgainstReference();
+  }
+
+  protected void verifyFromAgainstReference() {
+    assertEquals(reference.size(), from.size());
+    for (int i = 0; i < reference.size(); i++) {
+      assertEquals(reference.get(i), from.get(i));
+    }
+  }
+
+  protected void verifyToAgainstReference() {
+    assertEquals(reference.size(), to.size());
+    for (int i = 0; i < reference.size(); i++) {
+      assertEquals(reference.get(i), to.get(i).get());
+    }
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/transform/PreinitializedPropsListTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/transform/PreinitializedPropsListTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.model.transform;
+
+import jetbrains.jetpad.model.collections.list.ObservableArrayList;
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ValueProperty;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertEquals;
+
+public class PreinitializedPropsListTest extends BasePropsListTestCase {
+  @Override
+  public void initLists() {
+    from = new ObservableArrayList<>();
+    to = new ObservableArrayList<>();
+    reference = new ArrayList<>();
+    transformation = Transformers.toPropsListTwoWay().transform(from, to);
+  }
+
+  @Override
+  public void dispose() {
+    transformation.dispose();
+  }
+
+  @Test
+  public void verifyTransformation() {
+    assertTrue(transformation.getSource() == from);
+    assertTrue(transformation.getTarget() == to);
+  }
+
+  @Test
+  public void fillForward() {
+    fillFromAndReference();
+    verifyListsAgainstReference();
+  }
+
+  @Test
+  public void fillBackward() {
+    fillToAndReference();
+    verifyListsAgainstReference();
+  }
+
+  @Test
+  public void setForward() {
+    testItemsSet(new ItemSetter() {
+      @Override
+      public void doSet(int index, Object newItem) {
+        from.set(index, newItem);
+      }
+      @Override
+      public boolean newPropertyMustBeCreated() {
+        return false;
+      }
+    });
+  }
+
+  @Test
+  public void setBackwardValue() {
+    testItemsSet(new ItemSetter() {
+      @Override
+      public void doSet(int index, Object newItem) {
+        to.get(index).set(newItem);
+      }
+      @Override
+      public boolean newPropertyMustBeCreated() {
+        return false;
+      }
+    });
+  }
+
+  @Test
+  public void setBackwardProperty() {
+    testItemsSet(new ItemSetter() {
+      @Override
+      public void doSet(int index, Object newItem) {
+        to.set(index, new ValueProperty<>(newItem));
+      }
+      @Override
+      public boolean newPropertyMustBeCreated() {
+        return true;
+      }
+    });
+  }
+
+  private void testItemsSet(ItemSetter itemSetter) {
+    fillFrom();
+    for (int index : new int[] { 0, MIDDLE, LAST}) {
+      Property<Object> oldProperty = to.get(index);
+      Object newItem = new Object();
+      itemSetter.doSet(index, newItem);
+      Property<Object> newProperty = to.get(index);
+      if (itemSetter.newPropertyMustBeCreated()) {
+        assertTrue(oldProperty != newProperty);
+      } else {
+        assertTrue(oldProperty == newProperty);
+      }
+      assertEquals(newItem, from.get(index));
+      assertEquals(newItem, newProperty.get());
+    }
+  }
+
+  @Test
+  public void removeForward() {
+    testItemsRemove(new ItemRemover() {
+      @Override
+      public void doRemove(int index) {
+        from.remove(index);
+      }
+    });
+  }
+
+  @Test
+  public void removeBackward() {
+    testItemsRemove(new ItemRemover() {
+      @Override
+      public void doRemove(int index) {
+        to.remove(index);
+      }
+    });
+  }
+
+  private void testItemsRemove(ItemRemover itemRemover) {
+    fillFromAndReference();
+    for (int index : new int[] { LAST, MIDDLE, 0 }) {
+      itemRemover.doRemove(index);
+      reference.remove(index);
+      verifyListsAgainstReference();
+    }
+  }
+
+  @Test
+  public void clearForward() {
+    fillFrom();
+    from.clear();
+    checkBothListsEmpty();
+  }
+
+  @Test
+  public void clearBackward() {
+    fillFrom();
+    to.clear();
+    checkBothListsEmpty();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void duplicatesDetection() {
+    fillFrom();
+    Object duplicate = new Object();
+    from.set(MIDDLE, duplicate);
+    from.set(MIDDLE + 1, duplicate);
+    to.get(MIDDLE + 1).set(new Object());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullValuesNotSupported() {
+    from.add(new Object());
+    to.get(0).set(null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void nullPropertiesNotSupported() {
+    to.add(null);
+  }
+
+  private void checkBothListsEmpty() {
+    assertTrue(from.isEmpty());
+    assertTrue(to.isEmpty());
+  }
+
+  private interface ItemSetter {
+    void doSet(int index, Object newItem);
+    boolean newPropertyMustBeCreated();
+  }
+
+  private interface ItemRemover {
+    void doRemove(int index);
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/transform/PropsListInitializationAndDisposalTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/transform/PropsListInitializationAndDisposalTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.model.transform;
+
+import jetbrains.jetpad.model.collections.list.ObservableArrayList;
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ValueProperty;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static jetbrains.jetpad.model.transform.Transformers.toPropsListTwoWay;
+import static junit.framework.TestCase.assertEquals;
+
+public class PropsListInitializationAndDisposalTest extends BasePropsListTestCase {
+  private boolean disposeNeeded = false;
+
+  @Override
+  public void initLists() {
+    from = new ObservableArrayList<>();
+    reference = new ArrayList<>();
+  }
+
+  @Override
+  public void dispose() {
+    if (disposeNeeded) {
+      transformation.dispose();
+    }
+  }
+
+  @Test
+  public void useNonemptySourceList() {
+    fillFromAndReference();
+    transformation = toPropsListTwoWay().transform(from);
+    to = transformation.getTarget();
+    verifyListsAgainstReference();
+    disposeNeeded = true;
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void useNonemptyTargetList() {
+    to = new ObservableArrayList<>();
+    to.add(new ValueProperty<>(new Object()));
+    try {
+      toPropsListTwoWay().transform(from, to);
+    } finally {
+      disposeNeeded = false;
+    }
+  }
+
+  @Test
+  public void addRemoveAfterDisposal() {
+    fillAndDispose();
+    from.add(new Object());
+    to.remove(LAST);
+    assertEquals(FILL_SIZE + 1, from.size());
+    assertEquals(FILL_SIZE - 1, to.size());
+  }
+
+  @Test
+  public void setForwardAfterUnbinding() {
+    fillAndDispose();
+    Property<Object> oldProperty = to.get(MIDDLE);
+    Object oldItem = oldProperty.get();
+    from.set(MIDDLE, new Object());
+    assertEquals(oldProperty, to.get(MIDDLE));
+    assertEquals(oldItem, to.get(MIDDLE).get());
+  }
+
+  @Test
+  public void setBackwardValueAfterUnbinding() {
+    fillAndDispose();
+    Object oldItem = from.get(MIDDLE);
+    to.get(MIDDLE).set(new Object());
+    assertEquals(oldItem, from.get(MIDDLE));
+  }
+
+  @Test
+  public void setBackwardPropertyAfterUnbinding() {
+    fillAndDispose();
+    Object oldItem = from.get(MIDDLE);
+    to.set(MIDDLE, new ValueProperty<>(new Object()));
+    assertEquals(oldItem, from.get(MIDDLE));
+  }
+
+  private void fillAndDispose() {
+    transformation = toPropsListTwoWay().transform(from);
+    to = transformation.getTarget();
+    fillFrom();
+    transformation.dispose();
+    disposeNeeded = false;
+  }
+}


### PR DESCRIPTION
Main changes compared to previous request

* Optimized transformer, including changing Registrations HashMap to ArrayList, and reusing properties change listener
* Extracted role adapter off previously introduced unclear list hybrid sync
* Extracted null substitution delegate property off unclear list hybrid sync