### PR TITLE
Improved source-target indexing

### DIFF
--- a/mapper/src/main/java/jetbrains/jetpad/mapper/ByTargetIndex.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/ByTargetIndex.java
@@ -21,6 +21,10 @@ import jetbrains.jetpad.base.Registration;
 
 import java.util.Collection;
 
+/**
+ * @deprecated Use {@link MappingIndex} instead.
+ */
+@Deprecated
 public class ByTargetIndex {
   private Registration myRegistration;
 

--- a/mapper/src/main/java/jetbrains/jetpad/mapper/Mapper.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/Mapper.java
@@ -15,6 +15,7 @@
  */
 package jetbrains.jetpad.mapper;
 
+import jetbrains.jetpad.base.Registration;
 import jetbrains.jetpad.base.ThrowableHandlers;
 import jetbrains.jetpad.model.collections.list.ObservableArrayList;
 import jetbrains.jetpad.model.collections.list.ObservableList;
@@ -31,7 +32,7 @@ import java.util.List;
 /**
  * Mapper is an
  */
-public abstract class Mapper<SourceT, TargetT> {
+public abstract class Mapper<SourceT, TargetT> implements Mapping<SourceT, TargetT> {
   private static final Object[] EMPTY_PARTS = new Object[0];
 
   private SourceT mySource;
@@ -84,10 +85,12 @@ public abstract class Mapper<SourceT, TargetT> {
     return getMappingContext().getMapper(this, source);
   }
 
+  @Override
   public final SourceT getSource() {
     return mySource;
   }
 
+  @Override
   public final TargetT getTarget() {
     return myTarget;
   }
@@ -130,7 +133,6 @@ public abstract class Mapper<SourceT, TargetT> {
       ThrowableHandlers.handle(t);
     }
 
-
     myMappingContext = ctx;
 
     instantiateSynchronizers();
@@ -149,6 +151,17 @@ public abstract class Mapper<SourceT, TargetT> {
           @Override
           public Mapper<?, ?> getMapper() {
             return Mapper.this;
+          }
+
+          @Override
+          public Registration registerMapping(final Mapping<?, ?> mapping) {
+            myMappingContext.registerMapping(mapping);
+            return new Registration() {
+              @Override
+              protected void doRemove() {
+                myMappingContext.unregisterMapping(mapping);
+              }
+            };
           }
         });
       }

--- a/mapper/src/main/java/jetbrains/jetpad/mapper/Mapping.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/Mapping.java
@@ -15,11 +15,7 @@
  */
 package jetbrains.jetpad.mapper;
 
-/**
- * @deprecated Use {@link MappingsListener} instead.
- */
-@Deprecated
-public interface MappingContextListener {
-  void onMapperRegistered(Mapper<?, ?> mapper);
-  void onMapperUnregistered(Mapper<?, ?> mapper);
+public interface Mapping<SourceT, TargetT> {
+  SourceT getSource();
+  TargetT getTarget();
 }

--- a/mapper/src/main/java/jetbrains/jetpad/mapper/MappingIndex.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/MappingIndex.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.mapper;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import jetbrains.jetpad.base.Disposable;
+import jetbrains.jetpad.base.Registration;
+
+import java.util.Collection;
+
+public class MappingIndex implements Disposable {
+  private Multimap<Object, Mapping<?, ?>> mySourceIndex = HashMultimap.create();
+  private Multimap<Object, Mapping<?, ?>> myTargetIndex = HashMultimap.create();
+  private Registration myRegistration;
+
+  public MappingIndex(MappingContext ctx) {
+    for (Mapping<?, ?> mapping : ctx.getMappings()) {
+      add(mapping);
+    }
+
+    myRegistration = ctx.addListener(new MappingsListener() {
+      @Override
+      public void onMappingRegistered(Mapping<?, ?> mapping) {
+        add(mapping);
+      }
+
+      @Override
+      public void onMappingUnregistered(Mapping<?, ?> mapping) {
+        remove(mapping);
+      }
+    });
+  }
+
+  public Collection<Mapping<?, ?>> getBySource(Object source) {
+    return mySourceIndex.get(source);
+  }
+
+  public Collection<Mapping<?, ?>> getByTarget(Object target) {
+    return myTargetIndex.get(target);
+  }
+
+  public void dispose() {
+    myRegistration.remove();
+  }
+
+  private void remove(Mapping<?, ?> mapping) {
+    Object source = mapping.getSource();
+    if (!mySourceIndex.get(source).remove(mapping)) {
+      throw new IllegalStateException("unregistered unknown mapping " + mapping + " with source " + source);
+    }
+    Object target = mapping.getTarget();
+    if (!myTargetIndex.get(target).remove(mapping)) {
+      throw new IllegalStateException("unregistered unknown mapping " + mapping + " with target " + target);
+    }
+  }
+
+  private void add(Mapping<?, ?> mapping) {
+    mySourceIndex.put(mapping.getSource(), mapping);
+    myTargetIndex.put(mapping.getTarget(), mapping);
+  }
+}

--- a/mapper/src/main/java/jetbrains/jetpad/mapper/MappingsListener.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/MappingsListener.java
@@ -15,11 +15,7 @@
  */
 package jetbrains.jetpad.mapper;
 
-/**
- * @deprecated Use {@link MappingsListener} instead.
- */
-@Deprecated
-public interface MappingContextListener {
-  void onMapperRegistered(Mapper<?, ?> mapper);
-  void onMapperUnregistered(Mapper<?, ?> mapper);
+public interface MappingsListener {
+  void onMappingRegistered(Mapping<?, ?> mapping);
+  void onMappingUnregistered(Mapping<?, ?> mapping);
 }

--- a/mapper/src/main/java/jetbrains/jetpad/mapper/SimpleMapping.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/SimpleMapping.java
@@ -1,0 +1,21 @@
+package jetbrains.jetpad.mapper;
+
+public class SimpleMapping<SourceT, TargetT> implements Mapping<SourceT, TargetT> {
+  private final SourceT mySource;
+  private final TargetT myTarget;
+
+  public SimpleMapping(SourceT source, TargetT target) {
+    mySource = source;
+    myTarget = target;
+  }
+
+  @Override
+  public SourceT getSource() {
+    return mySource;
+  }
+
+  @Override
+  public TargetT getTarget() {
+    return myTarget;
+  }
+}

--- a/mapper/src/main/java/jetbrains/jetpad/mapper/SynchronizerContext.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/SynchronizerContext.java
@@ -15,7 +15,10 @@
  */
 package jetbrains.jetpad.mapper;
 
+import jetbrains.jetpad.base.Registration;
+
 public interface SynchronizerContext {
   MappingContext getMappingContext();
   Mapper<?, ?> getMapper();
+  Registration registerMapping(final Mapping<?, ?> mapping);
 }

--- a/mapper/src/test/java/jetbrains/jetpad/mapper/MappingIndexTest.java
+++ b/mapper/src/test/java/jetbrains/jetpad/mapper/MappingIndexTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.mapper;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.test.BaseTestCase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+
+public class MappingIndexTest extends BaseTestCase {
+  private MappingContext mappingContext;
+  private MappingIndex mappingIndex;
+
+  @Before
+  public void setUp() {
+    mappingContext = new MappingContext();
+    mappingIndex = new MappingIndex(mappingContext);
+  }
+
+  @Test
+  public void mapper() {
+    TestMapper mapper = new TestMapper("source", "target");
+    mapper.attachRoot(mappingContext);
+
+    assertBySource("source", mapper);
+    assertByTarget("target", mapper);
+
+    mapper.detachRoot();
+
+    assertBySource("source");
+    assertByTarget("target");
+  }
+
+  @Test
+  public void manyToMany() {
+    TestMapper testMapper11 = new TestMapper("source 1", "target 1");
+    testMapper11.attachRoot(mappingContext);
+    TestMapper testMapper12 = new TestMapper("source 1", "target 2");
+    testMapper12.attachRoot(mappingContext);
+    TestMapper testMapper21 = new TestMapper("source 2", "target 1");
+    testMapper21.attachRoot(mappingContext);
+    TestMapper testMapper22 = new TestMapper("source 2", "target 2");
+    testMapper22.attachRoot(mappingContext);
+
+    assertBySource("source 1", testMapper11, testMapper12);
+    assertBySource("source 2", testMapper21, testMapper22);
+    assertByTarget("target 1", testMapper11, testMapper21);
+    assertByTarget("target 2", testMapper12, testMapper22);
+
+    testMapper11.detachRoot();
+    testMapper12.detachRoot();
+    testMapper21.detachRoot();
+    testMapper22.detachRoot();
+
+    assertBySource("source 1");
+    assertBySource("source 2");
+    assertByTarget("target 1");
+    assertByTarget("target 2");
+  }
+
+  @Test
+  public void synchronizer() {
+    final SimpleMapping<String, String> testMapping = new SimpleMapping<>("sync source", "sync target");
+    TestMapper mapper = new TestMapper("source", "target") {
+      @Override
+      protected void registerSynchronizers(SynchronizersConfiguration conf) {
+        conf.add(new TestSynchronizer(testMapping));
+      }
+    };
+    mapper.attachRoot(mappingContext);
+
+    assertBySource("source", mapper);
+    assertBySource("sync source", testMapping);
+    assertByTarget("target", mapper);
+    assertByTarget("sync target", testMapping);
+
+    mapper.detachRoot();
+
+    assertBySource("source");
+    assertBySource("sync source");
+    assertByTarget("target");
+    assertByTarget("sync target");
+  }
+
+  @Test
+  public void addLater() {
+    TestMapper earlyMapper = new TestMapper("early source", "early target");
+    earlyMapper.attachRoot(mappingContext);
+
+    MappingIndex lateIndex = new MappingIndex(mappingContext);
+    TestMapper mapper = new TestMapper("source", "target");
+    mapper.attachRoot(mappingContext);
+
+    Assert.assertTrue(lateIndex.getBySource("early source").contains(earlyMapper));
+    Assert.assertTrue(lateIndex.getByTarget("early target").contains(earlyMapper));
+    Assert.assertTrue(lateIndex.getBySource("source").contains(mapper));
+    Assert.assertTrue(lateIndex.getByTarget("target").contains(mapper));
+  }
+
+  private void assertBySource(String source, Mapping... mappings) {
+    Collection<Mapping<?, ?>> bySource = mappingIndex.getBySource(source);
+    Assert.assertEquals(mappings.length, bySource.size());
+    for (Mapping m : mappings) {
+      Assert.assertTrue(bySource.contains(m));
+    }
+  }
+
+  private void assertByTarget(String target, Mapping... mappings) {
+    Collection<Mapping<?, ?>> byTarget = mappingIndex.getByTarget(target);
+    Assert.assertEquals(mappings.length, byTarget.size());
+    for (Mapping m : mappings) {
+      Assert.assertTrue(byTarget.contains(m));
+    }
+  }
+
+  private static class TestMapper extends Mapper<String, String> {
+    public TestMapper(String source, String target) {
+      super(source, target);
+    }
+  }
+
+  private static class TestSynchronizer implements Synchronizer {
+    private Mapping<?, ?> mapping;
+    private Registration r;
+
+    private TestSynchronizer(Mapping<?, ?> mapping) {
+      this.mapping = mapping;
+    }
+
+    @Override
+    public void attach(SynchronizerContext ctx) {
+      r = ctx.registerMapping(mapping);
+    }
+
+    @Override
+    public void detach() {
+      r.remove();
+    }
+  }
+}


### PR DESCRIPTION
 - Common interface for source:target pairs - Mapping
 - SynchronizerContext can be used to register mappings
 - New listeners infrastructure for the new interface
 - Index
 - Deprecated ByTargetIndex and older index-like methods restricted to Mappers