### PR TITLE
Shortened registration from disposable

### DIFF
--- a/model/src/main/java/jetbrains/jetpad/model/transform/Transformers.java
+++ b/model/src/main/java/jetbrains/jetpad/model/transform/Transformers.java
@@ -127,24 +127,15 @@ public class Transformers {
           public void onItemAdded(CollectionItemEvent<? extends SourceT> event) {
             final Transformation<SourceT, TargetT> transformation = transformer.transform(event.getNewItem());
             to.add(event.getIndex(), transformation.getTarget());
-            itemRegistrations.add(event.getIndex(), new Registration() {
-              @Override
-              protected void doRemove() {
-                transformation.dispose();
-              }
-            });
+            itemRegistrations.add(event.getIndex(), Registration.from(transformation));
           }
 
           @Override
           public void onItemSet(CollectionItemEvent<? extends SourceT> event) {
             final Transformation<SourceT, TargetT> transformation = transformer.transform(event.getNewItem());
             to.set(event.getIndex(), transformation.getTarget());
-            itemRegistrations.set(event.getIndex(), new Registration() {
-              @Override
-              protected void doRemove() {
-                transformation.dispose();
-              }
-            }).remove();
+            itemRegistrations.set(event.getIndex(), Registration.from(transformation))
+              .remove();
           }
 
           @Override

--- a/util/base/src/main/java/jetbrains/jetpad/base/Registration.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/Registration.java
@@ -26,6 +26,26 @@ public abstract class Registration implements Disposable {
     }
   };
 
+  public static Registration from(final Disposable disposable) {
+    return new Registration() {
+      @Override
+      protected void doRemove() {
+        disposable.dispose();
+      }
+    };
+  }
+
+  public static Registration from(final Disposable... disposables) {
+    return new Registration() {
+      @Override
+      protected void doRemove() {
+        for (Disposable d : disposables) {
+          d.dispose();
+        }
+      }
+    };
+  }
+
   private boolean myRemoved;
 
   protected abstract void doRemove();
@@ -33,7 +53,7 @@ public abstract class Registration implements Disposable {
   //this method should never be overridden except Registration.EMPTY
   public void remove() {
     if (myRemoved) {
-      throw new IllegalStateException();
+      throw new IllegalStateException("Registration already removed");
     }
     myRemoved = true;
     doRemove();


### PR DESCRIPTION
Utility to shorten wrapping disposables into registration with an example.
Note that in Java 8 this method could be used as `Registration.from(this::cleanup)` or similar.

Also updated ISE message to simplify debugging over obfuscated code.