### PR TITLE
Use clickable and readable 128bits random IDs in BaseId

### DIFF
--- a/model/src/main/java/jetbrains/jetpad/model/id/BaseId.java
+++ b/model/src/main/java/jetbrains/jetpad/model/id/BaseId.java
@@ -20,7 +20,6 @@ import jetbrains.jetpad.base.Objects;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 /**
  * Generic id class for typed ids.
@@ -35,8 +34,9 @@ public abstract class BaseId implements Serializable {
 
   private String myId;
 
+  // generate 62 ^ 22 (~130 bits) of random readable ID
   protected BaseId() {
-    this(IdGenerator.nextRandomId(), null);
+    this(IdGenerator.nextBase62RandomId(22), null);
   }
 
   protected BaseId(String id) {
@@ -99,34 +99,4 @@ public abstract class BaseId implements Serializable {
     }
   }
 
-  private static class IdGenerator {
-
-    private static final Random ourRandom = new Random();
-
-    // generate 128 bits (62 ^ 22) of random readable ID
-    private static String nextRandomId() {
-      char[] chars = new char[22];
-      int nBits = 0;
-      int bits = 0;
-
-      for (int i = 0; i < chars.length; ) {
-        if (nBits < 6) {
-          nBits = 32;
-          bits = ourRandom.nextInt();
-        }
-
-        int idx = bits & 63;
-        bits >>= 6;
-        nBits -= 6;
-        if (idx < 62) {
-          chars[i++] = valueToChar(idx);
-        }
-      }
-      return new String(chars);
-    }
-
-    private static char valueToChar(int x) {
-      return (char) (x < 26 ? 'A' + x : x < 52 ? 'a' + x - 26 : '0' + x - 52);
-    }
-  }
 }

--- a/model/src/main/java/jetbrains/jetpad/model/id/BaseId.java
+++ b/model/src/main/java/jetbrains/jetpad/model/id/BaseId.java
@@ -33,12 +33,10 @@ public abstract class BaseId implements Serializable {
 
   private static final Map<String, String> ourNamesMap = new HashMap<>();
 
-  private static final Random ourRandom = new Random();
-
   private String myId;
 
   protected BaseId() {
-    this(nextRandomId(), null);
+    this(IdGenerator.nextRandomId(), null);
   }
 
   protected BaseId(String id) {
@@ -101,29 +99,34 @@ public abstract class BaseId implements Serializable {
     }
   }
 
-  // generate 128 bits (62 ^ 22) of random readable ID
-  private static String nextRandomId() {
-    char[] chars = new char[22];
-    int nBits = 0;
-    int bits = 0;
+  private static class IdGenerator {
 
-    for (int i = 0; i < chars.length;) {
-      if (nBits < 6) {
-        nBits = 32;
-        bits = ourRandom.nextInt();
-      }
+    private static final Random ourRandom = new Random();
 
-      int idx = bits & 63;
-      bits >>= 6;
-      nBits -= 6;
-      if (idx < 62) {
-        chars[i++] = valueToChar(idx);
+    // generate 128 bits (62 ^ 22) of random readable ID
+    private static String nextRandomId() {
+      char[] chars = new char[22];
+      int nBits = 0;
+      int bits = 0;
+
+      for (int i = 0; i < chars.length; ) {
+        if (nBits < 6) {
+          nBits = 32;
+          bits = ourRandom.nextInt();
+        }
+
+        int idx = bits & 63;
+        bits >>= 6;
+        nBits -= 6;
+        if (idx < 62) {
+          chars[i++] = valueToChar(idx);
+        }
       }
+      return new String(chars);
     }
-    return new String(chars);
-  }
 
-  private static char valueToChar(int x) {
-    return (char) (x < 26 ? 'A' + x : x < 52 ? 'a' + x - 26 : '0' + x - 52);
+    private static char valueToChar(int x) {
+      return (char) (x < 26 ? 'A' + x : x < 52 ? 'a' + x - 26 : '0' + x - 52);
+    }
   }
 }

--- a/model/src/main/java/jetbrains/jetpad/model/id/IdGenerator.java
+++ b/model/src/main/java/jetbrains/jetpad/model/id/IdGenerator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.model.id;
+
+import java.util.Random;
+
+class IdGenerator {
+  private static final Random ourRandom = new Random();
+
+  static String nextBase62RandomId(int length) {
+    char[] chars = new char[length];
+    int nBits = 0;
+    int bits = 0;
+
+    for (int i = 0; i < chars.length; ) {
+      if (nBits < 6) {
+        nBits = 32;
+        bits = ourRandom.nextInt();
+      }
+
+      int idx = bits & 63;
+      bits >>= 6;
+      nBits -= 6;
+      if (idx < 62) {
+        chars[i++] = toChar(idx);
+      }
+    }
+    return new String(chars);
+  }
+
+  private static char toChar(int x) {
+    return (char) (x < 10 ? '0' + x : x < 36 ? 'a' + x - 10 : 'A' + x - 36);
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/id/BaseIdTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/id/BaseIdTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BaseIdTest {
 
@@ -44,6 +45,28 @@ public class BaseIdTest {
     MyId id2 = new MyId("a.b");
 
     assertEquals("newName1 [a.b]", id2.toString());
+  }
+
+  @Test
+  public void idRandomness() {
+    int stats[] = new int[128];
+
+    for (int i = 0; i < 62000; i++) {
+      String id = new BaseId() {}.getId();
+      for (int j = 0; j < id.length(); j++) {
+        stats[id.charAt(j)] ++;
+      }
+    }
+
+    checkUniform(stats, 'A', 'Z', 22000);
+    checkUniform(stats, 'a', 'z', 22000);
+    checkUniform(stats, '0', '9', 22000);
+  }
+
+  private void checkUniform(int[] stats, char a, char z, int expected) {
+    for (int i = a; i <= z; i++) {
+      assertTrue(Math.abs(stats[i] - expected) < expected / 10);
+    }
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/model/src/test/java/jetbrains/jetpad/model/id/BaseIdTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/id/BaseIdTest.java
@@ -15,13 +15,15 @@
  */
 package jetbrains.jetpad.model.id;
 
+import jetbrains.jetpad.test.BaseTestCase;
+import jetbrains.jetpad.test.Slow;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class BaseIdTest {
+public class BaseIdTest extends BaseTestCase {
 
   @Test
   public void idEquality() {
@@ -47,6 +49,7 @@ public class BaseIdTest {
     assertEquals("newName1 [a.b]", id2.toString());
   }
 
+  @Slow
   @Test
   public void idRandomness() {
     int stats[] = new int[128];


### PR DESCRIPTION
There is no difference in length between 62 based and 64 based 128-bits IDS

62 ^21 < 2 ^ 128 < 62 ^22 
64 ^21 < 2 ^ 128 < 64 ^22 

So we can use more human readable IDS, which is also single-clickable to select
