### PR TITLE
DP-2149 Prevent killing test event dispatch thread from inside scheduled task

### DIFF
--- a/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEdtManagerTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEdtManagerTest.java
@@ -69,4 +69,16 @@ public class TestEdtManagerTest {
     manager.finish();
     manager.getEdt().schedule(r);
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void killFromTask() {
+    manager.getEdt().schedule(() -> manager.kill());
+    manager.getEdt().executeUpdates();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void finishFromTask() {
+    manager.getEdt().schedule(() -> manager.finish());
+    manager.getEdt().executeUpdates();
+  }
 }

--- a/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEventDispatchThread.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEventDispatchThread.java
@@ -28,6 +28,7 @@ public final class TestEventDispatchThread implements EventDispatchThread {
   private int myModificationCount;
   private List<RunnableRecord> myRecords = new ArrayList<>();
   private boolean myFinished = false;
+  private boolean myRunning = false;
 
   public TestEventDispatchThread() {
     this("");
@@ -86,9 +87,11 @@ public final class TestEventDispatchThread implements EventDispatchThread {
   }
 
   private void run(List<RunnableRecord> current) {
+    myRunning = true;
     for (RunnableRecord r : current) {
       r.myRunnable.run();
     }
+    myRunning = false;
   }
 
   private List<RunnableRecord> getCurrentRecords() {
@@ -162,14 +165,22 @@ public final class TestEventDispatchThread implements EventDispatchThread {
     }
   }
 
+  private void checkInsideTask() {
+    if (myRunning) {
+      throw new IllegalStateException(this + " is running a task");
+    }
+  }
+
   void finish() {
     checkCanStop();
+    checkInsideTask();
     run(getCurrentRecords());
     shutdown();
   }
 
   void kill() {
     checkCanStop();
+    checkInsideTask();
     shutdown();
   }
 

--- a/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEventDispatchThreadTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEventDispatchThreadTest.java
@@ -61,4 +61,16 @@ public class TestEventDispatchThreadTest {
     edt.executeUpdates(2);
     Mockito.verify(r, times(2)).run();
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void killFromTask() {
+    edt.schedule(() -> edt.kill());
+    edt.executeUpdates();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void finishFromTask() {
+    edt.schedule(() -> edt.finish());
+    edt.executeUpdates();
+  }
 }


### PR DESCRIPTION
Fixes TestEventDispatchThread implementation to throw error if finish() or kill() is called from a scheduled task. Related to DP-1746 (JetBrains/jetpad-ot#233).