### PR TITLE
Asyncs.get patch and test utils

### DIFF
--- a/util/base/src/main/java/jetbrains/jetpad/base/Asserts.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/Asserts.java
@@ -1,0 +1,31 @@
+package jetbrains.jetpad.base;
+
+public class Asserts {
+  public static void assertSuccess(Async<Void> async) {
+    assertSuccess(async, null);
+  }
+
+  public static <T> void assertSuccess(Async<T> async, T expected) {
+    T value = Asyncs.get(async);
+    if (value == null) {
+      if (expected != null) {
+        throw new AssertionError("Expected: " + expected + ", but got: " + value);
+      }
+    } else if (!value.equals(expected)) {
+      throw new AssertionError("Expected: " + expected + ", but got: " + value);
+    }
+  }
+
+  public static void assertFailure(Async<?> async, Class<? extends Throwable> expected) {
+    try {
+      Asyncs.get(async);
+      throw new AssertionError("Async expected to fail: " + async);
+    } catch (Throwable t) {
+      if (!expected.isAssignableFrom(t.getClass())) {
+        throw new AssertionError("Async failed with unexpected exception expected=" + expected + ", exception=" + t);
+      }
+    }
+  }
+
+  private Asserts() { }
+}

--- a/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
@@ -17,6 +17,9 @@ package jetbrains.jetpad.base;
 
 import com.google.common.annotations.GwtCompatible;
 import com.google.common.annotations.GwtIncompatible;
+import jetbrains.jetpad.base.function.Consumer;
+import jetbrains.jetpad.base.function.Function;
+import jetbrains.jetpad.base.function.Supplier;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,9 +30,6 @@ import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import jetbrains.jetpad.base.function.Consumer;
-import jetbrains.jetpad.base.function.Function;
-import jetbrains.jetpad.base.function.Supplier;
 
 @GwtCompatible
 public class Asyncs {
@@ -425,7 +425,13 @@ public class Asyncs {
       }
     }
     if (error.get() != null) {
-      throw new RuntimeException(error.get());
+      if (error.get() instanceof RuntimeException) {
+        throw (RuntimeException) error.get();
+      } else if (error.get() instanceof Exception) {
+        throw new RuntimeException(error.get());
+      } else {
+        throw (Error) error.get();
+      }
     } else {
       return result.get();
     }

--- a/util/base/src/test/java/jetbrains/jetpad/base/AsyncsTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/AsyncsTest.java
@@ -16,15 +16,17 @@
 package jetbrains.jetpad.base;
 
 import jetbrains.jetpad.base.function.Consumer;
-import org.junit.Test;
-
-import java.util.Arrays;
 import jetbrains.jetpad.base.function.Function;
 import jetbrains.jetpad.base.function.Supplier;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -236,6 +238,33 @@ public class AsyncsTest {
   @Test
   public void failedFalse() {
     assertFalse(Asyncs.isFailed(Asyncs.constant(null)));
+  }
+
+  @Test
+  public void getFailure() {
+    IllegalStateException testRuntime = new IllegalStateException("test");
+    try {
+      Asyncs.get(Asyncs.failure(testRuntime));
+      fail("get expected to fail");
+    } catch (Throwable t) {
+      assertSame(testRuntime, t);
+    }
+
+    IOException testChecked = new IOException("test");
+    try {
+      Asyncs.get(Asyncs.failure(testChecked));
+      fail("get expected to fail");
+    } catch (Throwable t) {
+      assertSame(testChecked, t.getCause());
+    }
+
+    AssertionError testError = new AssertionError("test");
+    try {
+      Asyncs.get(Asyncs.failure(testError));
+      fail("get expected to fail");
+    } catch (Throwable t) {
+      assertSame(testError, t);
+    }
   }
 
   private void assertFailure(Async<?> async) {


### PR DESCRIPTION
Asyncs.get throws the original exception when possible
Utilities to assert on Async results in tests