### PR TITLE
introduce TestEdtManagers class to simplify work with multiple edt managers in tests

### DIFF
--- a/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEdtManagers.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEdtManagers.java
@@ -1,0 +1,104 @@
+package jetbrains.jetpad.base.edt;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.base.Value;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class TestEdtManagers implements EdtManagerFactory {
+  private final List<TestEdtManager> managers = new ArrayList<>();
+
+  @Override
+  public TestEdtManager createEdtManager(String name) {
+    final Value<Registration> removeReg = new Value<>(null);
+    final TestEdtManager manager = new TestEdtManager(name) {
+      @Override
+      public void finish() {
+        super.finish();
+        removeReg.get().remove();
+      }
+
+      @Override
+      public void kill() {
+        super.kill();
+        removeReg.get().remove();
+      }
+    };
+
+    managers.add(manager);
+    removeReg.set(new Registration() {
+      @Override
+      protected void doRemove() {
+        managers.remove(manager);
+      }
+    });
+
+    return manager;
+  }
+
+  public void flush() {
+    flush(false);
+  }
+
+  public void flush(int passedTime) {
+    for (int i = 0; i < passedTime; i++) {
+      flush(true);
+    }
+  }
+
+  public boolean nothingScheduled(int time) {
+    for (TestEdtManager manager : managers) {
+      if (!manager.getEdt().nothingScheduled(time)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public TestEdtManager getManager(String namePart) {
+    TestEdtManager result = null;
+    for (TestEdtManager edtManager : managers) {
+      if (edtManager.getEdt().getName().contains(namePart)) {
+        if (result != null) {
+          throw new IllegalStateException("two managers contain '" + namePart + "' in their names: "
+              + result + " and " + edtManager);
+        }
+        result = edtManager;
+      }
+    }
+    if (result == null) {
+      throw new IllegalStateException("no manager contains '" + namePart + "' in its name among " + managers);
+    } else {
+      return result;
+    }
+  }
+
+  public TestEventDispatchThread getEdt(String namePart) {
+    return getManager(namePart).getEdt();
+  }
+
+  List<TestEdtManager> getManagers() {
+    return Collections.unmodifiableList(managers);
+  }
+
+  private void flush(boolean incTime) {
+    int passedTime = incTime ? 1 : 0;
+    boolean finished = false;
+    while (!finished) {
+      finished = true;
+      int size = managers.size();
+      List<TestEdtManager> copy = new ArrayList<>(managers);
+      for (TestEdtManager manager : copy) {
+        int runCommandNum = manager.getEdt().executeUpdates(passedTime);
+        finished &= runCommandNum == 0;
+      }
+      if (managers.size() != size) {
+        finished = false;
+      }
+      //we should increase time only once
+      passedTime = 0;
+    }
+  }
+}

--- a/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEdtManagersTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEdtManagersTest.java
@@ -1,0 +1,96 @@
+package jetbrains.jetpad.base.edt;
+
+import jetbrains.jetpad.test.BaseTestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TestEdtManagersTest extends BaseTestCase {
+  private TestEdtManagers managers = new TestEdtManagers();
+
+  @Test
+  public void managerRemovedOnFinish() {
+    TestEdtManager manager = managers.createEdtManager("a");
+    manager.finish();
+
+    assertTrue(managers.getManagers().isEmpty());
+  }
+
+  @Test
+  public void managerRemovedOnKill() {
+    TestEdtManager manager = managers.createEdtManager("a");
+    manager.kill();
+
+    assertTrue(managers.getManagers().isEmpty());
+  }
+
+  @Test
+  public void managerByFullName() {
+    String name = "abc";
+    managers.createEdtManager(name);
+
+    assertEquals(name, managers.getEdt(name).getName());
+  }
+
+  @Test
+  public void managerByNamePart() {
+    String name = "abc";
+    managers.createEdtManager(name);
+
+    assertEquals(name, managers.getEdt("b").getName());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void noManagerByName() {
+    managers.getManager("no manager");
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void multipleManagersByNamePart() {
+    managers.createEdtManager("ab");
+    managers.createEdtManager("ac");
+
+    managers.getManager("a");
+  }
+
+  @Test
+  public void eventsOrder() {
+    final List<Integer> order = new ArrayList<>();
+
+    final TestEventDispatchThread a = managers.createEdtManager("a").getEdt();
+    final TestEventDispatchThread b = managers.createEdtManager("b").getEdt();
+
+    b.schedule(new Runnable() {
+      @Override
+      public void run() {
+        order.add(1);
+        a.schedule(new Runnable() {
+          @Override
+          public void run() {
+            order.add(2);
+          }
+        });
+      }
+    });
+    a.schedule(10, new Runnable() {
+      @Override
+      public void run() {
+        order.add(3);
+        b.schedule(new Runnable() {
+          @Override
+          public void run() {
+            order.add(4);
+          }
+        });
+      }
+    });
+
+    managers.flush(10);
+    assertEquals(Arrays.asList(1, 2, 3, 4), order);
+  }
+}


### PR DESCRIPTION
This class has been introduced in jetpad-ot. This pull request contains just copying it to jetpad-mapper. This is much simpler that creating connected pull requests to multiple repositories. After this one will be merged, I'll switch all current usages to class in jetpad-mapper and remove old one.   