### PR TITLE
make CompositeRegistration remove sub-registrations in order, reverse…

### DIFF
--- a/model/src/main/java/jetbrains/jetpad/model/event/CompositeRegistration.java
+++ b/model/src/main/java/jetbrains/jetpad/model/event/CompositeRegistration.java
@@ -18,7 +18,7 @@ package jetbrains.jetpad.model.event;
 import jetbrains.jetpad.base.Registration;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -30,7 +30,7 @@ public final class CompositeRegistration extends Registration {
 
   public CompositeRegistration(Registration... regs) {
     myRegistrations = new ArrayList<>(regs.length);
-    myRegistrations.addAll(Arrays.asList(regs));
+    Collections.addAll(myRegistrations, regs);
   }
 
   public CompositeRegistration add(Registration r) {
@@ -51,8 +51,8 @@ public final class CompositeRegistration extends Registration {
 
   @Override
   protected void doRemove() {
-    for (Registration r : myRegistrations) {
-      r.remove();
+    for (int i = myRegistrations.size() - 1; i > -1; i--) {
+      myRegistrations.get(i).remove();
     }
     myRegistrations.clear();
   }

--- a/model/src/test/java/jetbrains/jetpad/model/event/CompositeRegistrationTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/event/CompositeRegistrationTest.java
@@ -1,0 +1,35 @@
+package jetbrains.jetpad.model.event;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.test.BaseTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CompositeRegistrationTest extends BaseTestCase {
+  private int myRemoveCounter = 0;
+
+  @Test
+  public void removalOrder() {
+    CompositeRegistration r = new CompositeRegistration(createReg(1), createReg(0));
+    r.remove();
+    assertEquals(2, myRemoveCounter);
+  }
+
+  @Test
+  public void removalOrderManualAdd() {
+    CompositeRegistration r = new CompositeRegistration();
+    r.add(createReg(1)).add(createReg(0));
+    r.remove();
+    assertEquals(2, myRemoveCounter);
+  }
+
+  private Registration createReg(final int expectedOrder) {
+    return new Registration() {
+      @Override
+      protected void doRemove() {
+        assertEquals(expectedOrder, myRemoveCounter++);
+      }
+    };
+  }
+}


### PR DESCRIPTION
… to addition order

1) removed final modifier
2) slow tests pass for me
3) rolled back to ArrayList after discussion with @aleksei-berezkin 