### PR TITLE
Throwables shouldn't be catched on the server side

### DIFF
--- a/util/base/src/test/java/jetbrains/jetpad/base/ThrowableHandlersTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/ThrowableHandlersTest.java
@@ -19,9 +19,42 @@ import jetbrains.jetpad.base.function.Consumer;
 import jetbrains.jetpad.test.BaseTestCase;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 
 public class ThrowableHandlersTest extends BaseTestCase {
+
+  @Test
+  public void handleClientException() {
+    ThrowableHandlers.handleError(createGwtException());
+  }
+
+  @Test
+  public void handleClientError() {
+    ThrowableHandlers.handleError(createGwtError());
+  }
+
+  @Test
+  public void handleClientInnerError() {
+    ThrowableHandlers.handleError(new RuntimeException(createGwtError()));
+  }
+
+  @Test
+  public void handleServerException() {
+    ThrowableHandlers.handleError(new RuntimeException());
+  }
+
+  @Test(expected = NoClassDefFoundError.class)
+  public void handleServerError() {
+    ThrowableHandlers.handleError(new NoClassDefFoundError());
+  }
+
+  @Test(expected = NoClassDefFoundError.class)
+  public void handleServerInnerError() {
+    ThrowableHandlers.handleError(new RuntimeException(new NoClassDefFoundError()));
+  }
 
   @Test(expected = IllegalStateException.class)
   public void addThrowingThrowableHandler() {
@@ -60,5 +93,30 @@ public class ThrowableHandlersTest extends BaseTestCase {
       }
     });
     assertEquals(handlersSize - 1, ThrowableHandlers.getHandlersSize());
+  }
+
+
+  private Exception createGwtException() {
+    Exception e = new ClassCastException();
+    e.setStackTrace(getStackTrace());
+
+    return e;
+  }
+
+  private Error createGwtError() {
+    Error e = new NoClassDefFoundError();
+    e.setStackTrace(getStackTrace());
+
+    return e;
+  }
+
+  private StackTraceElement[] getStackTrace() {
+    List<StackTraceElement> stackTrace = new ArrayList<>();
+    stackTrace.add(new StackTraceElement("jetbrains.jetpad.base.ThrowableHandlersTest", "createGwtException",
+        "ThrowableHandlersTest.java", 100));
+    stackTrace.add(new StackTraceElement("com.google.gwt.core.client.impl.Impl", "apply", "Impl.java", 244));
+    stackTrace.add(new StackTraceElement("Unknown", "anonymous", "blob", 0));
+
+    return stackTrace.toArray(new StackTraceElement[0]);
   }
 }


### PR DESCRIPTION
That is an initial version where I implemented the following approach:

* we leave all current code "as is" and check (in ThrowableHandlers) every throwable and its "causes" if they are errors;
* we distinguish client exceptions from server ones by scanning the stacktrace;

This approach allows us to cover most of the scenarios with minimal code changes. We still have to embed this logic in some often-used places (like ExecutorEdtManager).