### PR TITLE
DP-2809 Remove duplicated code from ThreadSafeAsync

### DIFF
--- a/util/base/src/main/java/jetbrains/jetpad/base/AsyncResolver.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/AsyncResolver.java
@@ -1,0 +1,7 @@
+package jetbrains.jetpad.base;
+
+public interface AsyncResolver<ItemT> {
+  void success(ItemT result);
+
+  void failure(Throwable t);
+}

--- a/util/base/src/main/java/jetbrains/jetpad/base/AsyncResolver.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/AsyncResolver.java
@@ -1,6 +1,6 @@
 package jetbrains.jetpad.base;
 
-public interface AsyncResolver<ItemT> {
+interface AsyncResolver<ItemT> {
   void success(ItemT result);
 
   void failure(Throwable t);

--- a/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
@@ -311,7 +311,7 @@ public class Asyncs {
     return result;
   }
 
-  public static <ValueT> Registration delegate(Async<? extends ValueT> from, final SimpleAsync<? super ValueT> to) {
+  public static <ValueT> Registration delegate(Async<? extends ValueT> from, final AsyncResolver<? super ValueT> to) {
     return from.onResult(new Consumer<ValueT>() {
         @Override
         public void accept(ValueT item) {

--- a/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
@@ -70,7 +70,7 @@ public class Asyncs {
 
       @Override
       public <ResultT> Async<ResultT> map(final Function<? super ValueT, ? extends ResultT> success) {
-        return Asyncs.map(this, success);
+        return Asyncs.map(this, success, new SimpleAsync<ResultT>());
       }
 
       @Override
@@ -100,7 +100,7 @@ public class Asyncs {
 
       @Override
       public <ResultT> Async<ResultT> map(final Function<? super ValueT, ? extends ResultT> success) {
-        return Asyncs.map(this, success);
+        return Asyncs.map(this, success, new SimpleAsync<ResultT>());
       }
 
       @Override
@@ -116,12 +116,11 @@ public class Asyncs {
       public Void apply(ResultT input) {
         return null;
       }
-    });
+    }, new SimpleAsync<Void>());
   }
 
-  @Deprecated
-  public static <SourceT, TargetT, AsyncResultT extends SourceT> Async<TargetT> map(Async<AsyncResultT> async, final Function<SourceT, ? extends TargetT> f) {
-    final SimpleAsync<TargetT> result = new SimpleAsync<>();
+  static <SourceT, TargetT, AsyncResultT extends SourceT> Async<TargetT> map(Async<AsyncResultT> async,
+      final Function<SourceT, ? extends TargetT> f, final ResolvableAsync<TargetT> resultAsync) {
     async.onResult(new Consumer<AsyncResultT>() {
         @Override
         public void accept(AsyncResultT item) {
@@ -129,19 +128,19 @@ public class Asyncs {
           try {
             apply = f.apply(item);
           } catch (Exception e) {
-            result.failure(e);
+            resultAsync.failure(e);
             return;
           }
-          result.success(apply);
+          resultAsync.success(apply);
         }
       },
       new Consumer<Throwable>() {
         @Override
         public void accept(Throwable throwable) {
-          result.failure(throwable);
-        }
-      });
-    return result;
+          resultAsync.failure(throwable);
+          }
+        });
+    return resultAsync;
   }
 
   @Deprecated

--- a/util/base/src/main/java/jetbrains/jetpad/base/ResolvableAsync.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/ResolvableAsync.java
@@ -1,0 +1,4 @@
+package jetbrains.jetpad.base;
+
+public interface ResolvableAsync<ItemT> extends Async<ItemT>, AsyncResolver<ItemT> {
+}

--- a/util/base/src/main/java/jetbrains/jetpad/base/ResolvableAsync.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/ResolvableAsync.java
@@ -1,4 +1,4 @@
 package jetbrains.jetpad.base;
 
-public interface ResolvableAsync<ItemT> extends Async<ItemT>, AsyncResolver<ItemT> {
+interface ResolvableAsync<ItemT> extends Async<ItemT>, AsyncResolver<ItemT> {
 }

--- a/util/base/src/main/java/jetbrains/jetpad/base/SimpleAsync.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/SimpleAsync.java
@@ -20,7 +20,7 @@ import java.util.List;
 import jetbrains.jetpad.base.function.Consumer;
 import jetbrains.jetpad.base.function.Function;
 
-public final class SimpleAsync<ItemT> implements Async<ItemT> {
+public final class SimpleAsync<ItemT> implements ResolvableAsync<ItemT> {
   private ItemT mySuccessItem = null;
   private boolean mySucceeded = false;
 

--- a/util/base/src/main/java/jetbrains/jetpad/base/SimpleAsync.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/SimpleAsync.java
@@ -88,7 +88,7 @@ public final class SimpleAsync<ItemT> implements ResolvableAsync<ItemT> {
 
   @Override
   public <ResultT> Async<ResultT> flatMap(final Function<? super ItemT, Async<ResultT>> success) {
-    return Asyncs.select(this, success);
+    return Asyncs.select(this, success, new SimpleAsync<ResultT>());
   }
 
   public void success(ItemT item) {

--- a/util/base/src/main/java/jetbrains/jetpad/base/SimpleAsync.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/SimpleAsync.java
@@ -83,9 +83,7 @@ public final class SimpleAsync<ItemT> implements ResolvableAsync<ItemT> {
 
   @Override
   public <ResultT> Async<ResultT> map(final Function<? super ItemT, ? extends ResultT> success) {
-    SimpleAsync<ResultT> result = new SimpleAsync<>();
-    Asyncs.delegate(Asyncs.map(this, success), result);
-    return result;
+    return Asyncs.map(this, success, new SimpleAsync<ResultT>());
   }
 
   @Override

--- a/util/base/src/main/java/jetbrains/jetpad/base/ThreadSafeAsync.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/ThreadSafeAsync.java
@@ -18,7 +18,7 @@ package jetbrains.jetpad.base;
 import jetbrains.jetpad.base.function.Consumer;
 import jetbrains.jetpad.base.function.Function;
 
-public final class ThreadSafeAsync<ItemT> implements Async<ItemT> {
+public final class ThreadSafeAsync<ItemT> implements ResolvableAsync<ItemT> {
   private final SimpleAsync<ItemT> myAsync;
 
   public ThreadSafeAsync() {

--- a/util/base/src/main/java/jetbrains/jetpad/base/ThreadSafeAsync.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/ThreadSafeAsync.java
@@ -49,28 +49,7 @@ public final class ThreadSafeAsync<ItemT> implements ResolvableAsync<ItemT> {
   @Override
   public <ResultT> Async<ResultT> map(final Function<? super ItemT, ? extends ResultT> success) {
     synchronized (myAsync) {
-      final ThreadSafeAsync<ResultT> result = new ThreadSafeAsync<>();
-      myAsync.onResult(
-          new Consumer<ItemT>() {
-            @Override
-            public void accept(ItemT item) {
-              ResultT apply;
-              try {
-                apply = success.apply(item);
-              } catch (Exception e) {
-                result.failure(e);
-                return;
-              }
-              result.success(apply);
-            }
-          },
-          new Consumer<Throwable>() {
-            @Override
-            public void accept(Throwable throwable) {
-              result.failure(throwable);
-            }
-          });
-      return result;
+      return Asyncs.map(this, success, new ThreadSafeAsync<ResultT>());
     }
   }
 

--- a/util/base/src/test/java/jetbrains/jetpad/base/AsyncsTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/AsyncsTest.java
@@ -49,7 +49,7 @@ public class AsyncsTest {
       public Integer apply(Integer input) {
         return input + 1;
       }
-    });
+    }, new SimpleAsync<Integer>());
     assertSuccess(mapped, 240);
   }
 
@@ -61,7 +61,7 @@ public class AsyncsTest {
       public Integer apply(Integer input) {
         return input + 1;
       }
-    }));
+    }, new SimpleAsync<Integer>()));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -96,7 +96,7 @@ public class AsyncsTest {
       public Object apply(Object i) {
         throw new RuntimeException("test");
       }
-    }));
+    }, new SimpleAsync<>()));
   }
 
   @Test

--- a/util/base/src/test/java/jetbrains/jetpad/base/AsyncsTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/AsyncsTest.java
@@ -137,7 +137,7 @@ public class AsyncsTest {
   @Test
   public void selectReturnedFailure() {
     Async<Integer> async = Asyncs.constant(1);
-    assertFailure(Asyncs.select(async, new Function<Integer, Async<Integer>>() {
+    assertFailure(async.flatMap(new Function<Integer, Async<Integer>>() {
       @Override
       public Async<Integer> apply(Integer input) {
         return Asyncs.failure(new Throwable());


### PR DESCRIPTION
ThreadSafeAsync has map/flatMap implementation copy-pasted from Asyncs.map/select with minor changes.
This PR aims on removing this duplication and also restricts map/select methods to internal use only (they were deprecated long ago).