### PR TITLE
all/any for observables

### DIFF
--- a/model/src/main/java/jetbrains/jetpad/model/collections/list/ObservableCollections.java
+++ b/model/src/main/java/jetbrains/jetpad/model/collections/list/ObservableCollections.java
@@ -168,8 +168,7 @@ public class ObservableCollections {
             somethingChanged();
           }
         });
-        myCount = simpleCount
-            (predicate, collection);
+        myCount = simpleCount(predicate, collection);
       }
 
       @Override
@@ -181,8 +180,7 @@ public class ObservableCollections {
       @Override
       protected Integer doGet() {
         if (myCollectionRegistration == null) {
-          return simpleCount
-              (predicate, collection);
+          return simpleCount(predicate, collection);
         } else {
           return myCount;
         }
@@ -190,8 +188,7 @@ public class ObservableCollections {
     };
   }
 
-  private static <ItemT> int simpleCount
-      (final Predicate<? super ItemT> predicate, final Collection<ItemT> collection) {
+  private static <ItemT> int simpleCount(final Predicate<? super ItemT> predicate, final Collection<ItemT> collection) {
     int count = 0;
     for (ItemT i : collection) {
       if (predicate.test(i)) {

--- a/model/src/test/java/jetbrains/jetpad/model/collections/list/ObservableCollectionsTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/collections/list/ObservableCollectionsTest.java
@@ -1,0 +1,54 @@
+package jetbrains.jetpad.model.collections.list;
+
+import jetbrains.jetpad.base.function.Predicate;
+import jetbrains.jetpad.model.collections.ObservableCollection;
+import jetbrains.jetpad.model.property.ReadableProperty;
+import jetbrains.jetpad.test.BaseTestCase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ObservableCollectionsTest extends BaseTestCase {
+  @Test
+  public void allTest() {
+    ObservableCollection<String> collection = new ObservableArrayList<>();
+    ReadableProperty<Boolean> all = ObservableCollections.all(collection, new Predicate<String>() {
+      @Override
+      public boolean test(String s) {
+        return s.startsWith("a");
+      }
+    });
+    assertTrue(all.get());
+
+    collection.add("a");
+    assertTrue(all.get());
+    collection.add("b");
+    assertFalse(all.get());
+
+    collection.clear();
+    assertTrue(all.get());
+  }
+
+  @Test
+  public void anyTest() {
+    ObservableCollection<String> collection = new ObservableArrayList<>();
+    ReadableProperty<Boolean> any = ObservableCollections.any(collection, new Predicate<String>() {
+      @Override
+      public boolean test(String s) {
+        return s.startsWith("a");
+      }
+    });
+
+    assertFalse(any.get());
+
+    collection.add("b");
+    assertFalse(any.get());
+    collection.add("a");
+    assertTrue(any.get());
+
+    collection.clear();
+    assertFalse(any.get());
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/collections/list/ObservableCollectionsTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/collections/list/ObservableCollectionsTest.java
@@ -1,25 +1,57 @@
 package jetbrains.jetpad.model.collections.list;
 
+import jetbrains.jetpad.base.Value;
 import jetbrains.jetpad.base.function.Predicate;
+import jetbrains.jetpad.base.function.Supplier;
 import jetbrains.jetpad.model.collections.ObservableCollection;
+import jetbrains.jetpad.model.event.EventHandler;
+import jetbrains.jetpad.model.property.PropertyChangeEvent;
 import jetbrains.jetpad.model.property.ReadableProperty;
 import jetbrains.jetpad.test.BaseTestCase;
-import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ObservableCollectionsTest extends BaseTestCase {
+
+  private static final Predicate<String> STARTS_WITH_A = new Predicate<String>() {
+    @Override
+    public boolean test(String s) {
+      return s.startsWith("a");
+    }
+  };
+
+  @Test
+  public void count() {
+    ObservableList<String> collection = new ObservableArrayList<>();
+    ReadableProperty<Integer> count = ObservableCollections.count(collection, STARTS_WITH_A);
+
+    runChanges(collection, count);
+  }
+
+  @Test
+  public void countListener() {
+    ObservableList<String> collection = new ObservableArrayList<>();
+    ReadableProperty<Integer> count = ObservableCollections.count(collection, STARTS_WITH_A);
+
+    final Value<Integer> lastUpdate = new Value<>(0);
+    count.addHandler(new EventHandler<PropertyChangeEvent<Integer>>() {
+      @Override
+      public void onEvent(PropertyChangeEvent<Integer> event) {
+        lastUpdate.set(event.getNewValue());
+      }
+    });
+
+    runChanges(collection, lastUpdate);
+  }
+
   @Test
   public void allTest() {
     ObservableCollection<String> collection = new ObservableArrayList<>();
-    ReadableProperty<Boolean> all = ObservableCollections.all(collection, new Predicate<String>() {
-      @Override
-      public boolean test(String s) {
-        return s.startsWith("a");
-      }
-    });
+    ReadableProperty<Boolean> all = ObservableCollections.all(collection, STARTS_WITH_A);
+
     assertTrue(all.get());
 
     collection.add("a");
@@ -34,12 +66,7 @@ public class ObservableCollectionsTest extends BaseTestCase {
   @Test
   public void anyTest() {
     ObservableCollection<String> collection = new ObservableArrayList<>();
-    ReadableProperty<Boolean> any = ObservableCollections.any(collection, new Predicate<String>() {
-      @Override
-      public boolean test(String s) {
-        return s.startsWith("a");
-      }
-    });
+    ReadableProperty<Boolean> any = ObservableCollections.any(collection, STARTS_WITH_A);
 
     assertFalse(any.get());
 
@@ -50,5 +77,26 @@ public class ObservableCollectionsTest extends BaseTestCase {
 
     collection.clear();
     assertFalse(any.get());
+  }
+
+  private void runChanges(ObservableList<String> collection, Supplier<Integer> count) {
+    assertEquals(Integer.valueOf(0), count.get());
+
+    collection.add("a");
+    assertEquals(Integer.valueOf(1), count.get());
+    collection.add("b");
+    assertEquals(Integer.valueOf(1), count.get());
+    collection.add("a");
+    assertEquals(Integer.valueOf(2), count.get());
+    collection.add("b");
+    assertEquals(Integer.valueOf(2), count.get());
+
+    collection.remove(1);
+    assertEquals(Integer.valueOf(2), count.get());
+    collection.remove(1);
+    assertEquals(Integer.valueOf(1), count.get());
+
+    collection.clear();
+    assertEquals(Integer.valueOf(0), count.get());
   }
 }


### PR DESCRIPTION
We had an ad hoc 'any' implementation in SharingSettingsMapper. 'all' could also be useful.