### PR TITLE
Introduce transparent map-wrappers for observable collections

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -11,6 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <junit.version>4.11</junit.version>
+    <hamcrest.version>1.3</hamcrest.version>
     <mockito.version>1.9.5</mockito.version>
 
     <guava.version>20.0-rc1</guava.version>
@@ -63,6 +64,13 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-library</artifactId>
+        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>

--- a/model/src/main/java/jetbrains/jetpad/model/collections/wrappers/Events.java
+++ b/model/src/main/java/jetbrains/jetpad/model/collections/wrappers/Events.java
@@ -1,0 +1,13 @@
+package jetbrains.jetpad.model.collections.wrappers;
+
+import jetbrains.jetpad.base.function.Function;
+import jetbrains.jetpad.model.collections.CollectionItemEvent;
+
+class Events {
+  static <TargetItemT, SourceItemT> CollectionItemEvent<TargetItemT> wrapEvent(
+      CollectionItemEvent<? extends SourceItemT> event, Function<SourceItemT, TargetItemT> f) {
+    TargetItemT oldItem = event.getOldItem() != null ? f.apply(event.getOldItem()) : null;
+    TargetItemT newItem = event.getNewItem() != null ? f.apply(event.getNewItem()) : null;
+    return new CollectionItemEvent<>(oldItem, newItem, event.getIndex(), event.getType());
+  }
+}

--- a/model/src/main/java/jetbrains/jetpad/model/collections/wrappers/ObservableListWrapper.java
+++ b/model/src/main/java/jetbrains/jetpad/model/collections/wrappers/ObservableListWrapper.java
@@ -1,0 +1,81 @@
+package jetbrains.jetpad.model.collections.wrappers;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.base.function.Function;
+import jetbrains.jetpad.model.collections.CollectionItemEvent;
+import jetbrains.jetpad.model.collections.CollectionListener;
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import jetbrains.jetpad.model.event.EventHandler;
+
+import java.util.AbstractList;
+
+import static jetbrains.jetpad.model.collections.wrappers.Events.wrapEvent;
+
+public class ObservableListWrapper<SourceItemT, TargetItemT> extends AbstractList<TargetItemT> implements ObservableList<TargetItemT> {
+  private final ObservableList<SourceItemT> mySource;
+  private final Function<SourceItemT, TargetItemT> myStoT;
+  private final Function<TargetItemT, SourceItemT> myTtoS;
+
+  public ObservableListWrapper(ObservableList<SourceItemT> source, Function<SourceItemT, TargetItemT> toTarget, Function<TargetItemT, SourceItemT> toSource) {
+    mySource = source;
+    myStoT = toTarget;
+    myTtoS = toSource;
+  }
+
+  @Override
+  public Registration addListener(final CollectionListener<TargetItemT> l) {
+    return mySource.addListener(new CollectionListener<SourceItemT>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends SourceItemT> event) {
+        l.onItemAdded(wrapEvent(event, myStoT));
+      }
+
+      @Override
+      public void onItemSet(CollectionItemEvent<? extends SourceItemT> event) {
+        l.onItemSet(wrapEvent(event, myStoT));
+      }
+
+      @Override
+      public void onItemRemoved(CollectionItemEvent<? extends SourceItemT> event) {
+        l.onItemRemoved(wrapEvent(event, myStoT));
+      }
+    });
+  }
+
+  @Override
+  public Registration addHandler(final EventHandler<? super CollectionItemEvent<? extends TargetItemT>> handler) {
+    return mySource.addHandler(new EventHandler<CollectionItemEvent<? extends SourceItemT>>() {
+      @Override
+      public void onEvent(CollectionItemEvent<? extends SourceItemT> event) {
+        handler.onEvent(wrapEvent(event, myStoT));
+      }
+    });
+  }
+
+  @Override
+  public void add(int index, TargetItemT element) {
+    mySource.add(index, myTtoS.apply(element));
+  }
+
+  @Override
+  public TargetItemT set(int index, TargetItemT element) {
+    SourceItemT old = mySource.set(index, myTtoS.apply(element));
+    return old != null ? myStoT.apply(old) : null;
+  }
+
+  @Override
+  public TargetItemT get(int index) {
+    return myStoT.apply(mySource.get(index));
+  }
+
+  @Override
+  public TargetItemT remove(int index) {
+    SourceItemT old = mySource.remove(index);
+    return old != null ? myStoT.apply(old) : null;
+  }
+
+  @Override
+  public int size() {
+    return mySource.size();
+  }
+}

--- a/model/src/main/java/jetbrains/jetpad/model/collections/wrappers/ObservableSetWrapper.java
+++ b/model/src/main/java/jetbrains/jetpad/model/collections/wrappers/ObservableSetWrapper.java
@@ -1,0 +1,166 @@
+package jetbrains.jetpad.model.collections.wrappers;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.base.function.Function;
+import jetbrains.jetpad.model.collections.CollectionItemEvent;
+import jetbrains.jetpad.model.collections.CollectionListener;
+import jetbrains.jetpad.model.collections.set.ObservableSet;
+import jetbrains.jetpad.model.event.EventHandler;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+
+import static jetbrains.jetpad.model.collections.wrappers.Events.wrapEvent;
+
+public class ObservableSetWrapper<SourceItemT, TargetItemT> implements ObservableSet<TargetItemT> {
+  private final ObservableSet<SourceItemT> mySource;
+  private final Function<SourceItemT, TargetItemT> myStoT;
+  private final Function<TargetItemT, SourceItemT> myTtoS;
+
+  public ObservableSetWrapper(ObservableSet<SourceItemT> source, Function<SourceItemT, TargetItemT> toTarget, Function<TargetItemT, SourceItemT> toSource) {
+    mySource = source;
+    myStoT = toTarget;
+    myTtoS = toSource;
+  }
+
+  @Override
+  public Registration addListener(final CollectionListener<TargetItemT> l) {
+    return mySource.addListener(new CollectionListener<SourceItemT>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends SourceItemT> event) {
+        l.onItemAdded(wrapEvent(event, myStoT));
+      }
+
+      @Override
+      public void onItemSet(CollectionItemEvent<? extends SourceItemT> event) {
+        l.onItemSet(wrapEvent(event, myStoT));
+      }
+
+      @Override
+      public void onItemRemoved(CollectionItemEvent<? extends SourceItemT> event) {
+        l.onItemRemoved(wrapEvent(event, myStoT));
+      }
+    });
+  }
+
+  @Override
+  public Registration addHandler(final EventHandler<? super CollectionItemEvent<? extends TargetItemT>> handler) {
+    return mySource.addHandler(new EventHandler<CollectionItemEvent<? extends SourceItemT>>() {
+      @Override
+      public void onEvent(CollectionItemEvent<? extends SourceItemT> event) {
+        handler.onEvent(wrapEvent(event, myStoT));
+      }
+    });
+  }
+
+  @Override
+  public int size() {
+    return mySource.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return mySource.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    if (o == null) return false;
+    return mySource.contains(myTtoS.apply((TargetItemT) o));
+  }
+
+  @Override
+  public Iterator<TargetItemT> iterator() {
+    return new Iterator<TargetItemT>() {
+      private Iterator<SourceItemT> myIterator = mySource.iterator();
+
+      @Override
+      public boolean hasNext() {
+        return myIterator.hasNext();
+      }
+
+      @Override
+      public TargetItemT next() {
+        return myStoT.apply(myIterator.next());
+      }
+
+      @Override
+      public void remove() {
+        myIterator.remove();
+      }
+    };
+  }
+
+  @Override
+  public Object[] toArray() {
+    Object[] result = new Object[mySource.size()];
+    int current = 0;
+    for (SourceItemT item : mySource) {
+      result[current++] = myStoT.apply(item);
+    }
+    return result;
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return new HashSet<>(this).toArray(a);
+  }
+
+  @Override
+  public boolean add(TargetItemT wrapper) {
+    return mySource.add(myTtoS.apply(wrapper));
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    return mySource.remove(myTtoS.apply((TargetItemT) o));
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    for (Object o : c) {
+      if (!mySource.contains(myTtoS.apply((TargetItemT) o))) return false;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends TargetItemT> c) {
+    boolean changed = false;
+    for (TargetItemT w : c) {
+      if (add(w)) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    Iterator<TargetItemT> it = iterator();
+    while (it.hasNext()) {
+      TargetItemT current = it.next();
+      if (!c.contains(current)) {
+        it.remove();
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    boolean changed = false;
+    for (Object o : c) {
+      if (mySource.remove(myTtoS.apply((TargetItemT) o))) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  @Override
+  public void clear() {
+    mySource.clear();
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/collections/ObservableItemEventMatchers.java
+++ b/model/src/test/java/jetbrains/jetpad/model/collections/ObservableItemEventMatchers.java
@@ -1,0 +1,59 @@
+package jetbrains.jetpad.model.collections;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import static jetbrains.jetpad.model.collections.CollectionItemEvent.EventType.ADD;
+import static jetbrains.jetpad.model.collections.CollectionItemEvent.EventType.REMOVE;
+import static jetbrains.jetpad.model.collections.CollectionItemEvent.EventType.SET;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+public class ObservableItemEventMatchers {
+  public static <T> Matcher<CollectionItemEvent<? extends T>> event(final Matcher<? super T> oldItem, final Matcher<? super T> newItem,
+                                                             final Matcher<Integer> index, final Matcher<CollectionItemEvent.EventType> type) {
+    return new TypeSafeDiagnosingMatcher<CollectionItemEvent<? extends T>>() {
+      @Override
+      protected boolean matchesSafely(CollectionItemEvent<? extends T> event, Description description) {
+        if (!type.matches(event.getType())) {
+          description.appendText("type was ").appendValue(event.getType());
+          return false;
+        }
+        if (!oldItem.matches(event.getOldItem())) {
+          description.appendText("old item was ").appendValue(event.getOldItem());
+          return false;
+        }
+        if (!newItem.matches(event.getNewItem())) {
+          description.appendText("new item was ").appendValue(event.getNewItem());
+          return false;
+        }
+        if (!index.matches(event.getIndex())) {
+          description.appendText("index was ").appendValue(event.getIndex());
+          return false;
+        }
+        return true;
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("an ").appendDescriptionOf(type).appendText(" event with ")
+            .appendText("old item ").appendDescriptionOf(oldItem).appendText(", ")
+            .appendText("new item ").appendDescriptionOf(newItem).appendText(", ")
+            .appendText("index ").appendDescriptionOf(index);
+      }
+    };
+  }
+
+  public static <T> Matcher<CollectionItemEvent<? extends T>> addEvent(final Matcher<? super T> item, final Matcher<Integer> index) {
+    return event(nullValue(), item, index, equalTo(ADD));
+  }
+
+  public static <T> Matcher<CollectionItemEvent<? extends T>> setEvent(final Matcher<? super T> oldItem, final Matcher<? super T> newItem, final Matcher<Integer> index) {
+    return event(oldItem, newItem, index, equalTo(SET));
+  }
+
+  public static <T> Matcher<CollectionItemEvent<? extends T>> removeEvent(final Matcher<? super T> item, final Matcher<Integer> index) {
+    return event(item, nullValue(), index, equalTo(REMOVE));
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/collections/wrappers/ObservableListWrapperTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/collections/wrappers/ObservableListWrapperTest.java
@@ -1,0 +1,230 @@
+package jetbrains.jetpad.model.collections.wrappers;
+
+import jetbrains.jetpad.base.function.Function;
+import jetbrains.jetpad.model.collections.CollectionAdapter;
+import jetbrains.jetpad.model.collections.CollectionItemEvent;
+import jetbrains.jetpad.model.collections.CollectionListener;
+import jetbrains.jetpad.model.collections.list.ObservableArrayList;
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static jetbrains.jetpad.model.collections.ObservableItemEventMatchers.*;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class ObservableListWrapperTest {
+  private ObservableList<Double> source = new ObservableArrayList<>();
+  private Function<Double, Integer> toTarget = new Function<Double, Integer>() {
+    @Override
+    public Integer apply(Double value) {
+      return value.intValue() + 1;
+    }
+  };
+  private Function<Integer, Double> toSource = new Function<Integer, Double>() {
+    @Override
+    public Double apply(Integer value) {
+      return Integer.valueOf(value - 1).doubleValue();
+    }
+  };
+  private ObservableList<Integer> target = new ObservableListWrapper<>(source, toTarget, toSource);
+
+  private List<CollectionItemEvent<?extends Integer>> addEvents = new ArrayList<>();
+  private List<CollectionItemEvent<?extends Integer>> setEvents = new ArrayList<>();
+  private List<CollectionItemEvent<?extends Integer>> removeEvents = new ArrayList<>();
+  private CollectionListener<Integer> listener = new CollectionListener<Integer>() {
+    @Override
+    public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+      addEvents.add(event);
+    }
+
+    @Override
+    public void onItemSet(CollectionItemEvent<? extends Integer> event) {
+      setEvents.add(event);
+    }
+
+    @Override
+    public void onItemRemoved(CollectionItemEvent<? extends Integer> event) {
+      removeEvents.add(event);
+    }
+  };
+  private void assertEvents(int addCount, int setCount, int removeCount) {
+    assertThat(addEvents,    hasSize(addCount));
+    assertThat(setEvents,    hasSize(setCount));
+    assertThat(removeEvents, hasSize(removeCount));
+  }
+
+
+  @Before
+  public void setup() {
+    source.addAll(Arrays.asList(10.0, 20.0, 30.0));
+    target.addListener(listener);
+  }
+
+  @Test
+  public void listMapMaps() {
+    assertThat(target, contains(11, 21, 31));
+  }
+
+  @Test
+  public void listMapAddSource() {
+    source.add(1, 15.0);
+    assertThat(target, contains(11, 16, 21, 31));
+    assertEvents(1, 0, 0);
+    assertThat(addEvents.get(0), is(addEvent(equalTo(16), equalTo(1))));
+  }
+
+  @Test
+  public void listMapAddTarget() {
+    target.add(1, 15);
+    assertThat(target, contains(11, 15, 21, 31));
+    assertThat(source, contains(10.0, 14.0, 20.0, 30.0));
+    assertEvents(1, 0, 0);
+    assertThat(addEvents.get(0), is(addEvent(equalTo(15), equalTo(1))));
+  }
+
+  @Test
+  public void listMapSetSource() {
+    source.set(0, 15.0);
+    assertThat(target, contains(16, 21, 31));
+    assertEvents(0, 1, 0);
+    assertThat(setEvents.get(0), is(setEvent(equalTo(11), equalTo(16), equalTo(0))));
+  }
+
+  @Test
+  public void listMapSetTarget() {
+    target.set(0, 15);
+    assertThat(target, contains(15, 21, 31));
+    assertThat(source, contains(14.0, 20.0, 30.0));
+    assertEvents(0, 1, 0);
+    assertThat(setEvents.get(0), is(setEvent(equalTo(11), equalTo(15), equalTo(0))));
+  }
+
+  @Test
+  public void listMapRemoveSource() {
+    source.remove(2);
+    assertThat(target, contains(11, 21));
+    assertEvents(0, 0, 1);
+    assertThat(removeEvents.get(0), is(removeEvent(equalTo(31), equalTo(2))));
+  }
+
+  @Test
+  public void listMapRemoveTarget() {
+    target.remove(2);
+    assertThat(target, contains(11, 21));
+    assertThat(source, contains(10.0, 20.0));
+    assertEvents(0, 0, 1);
+    assertThat(removeEvents.get(0), is(removeEvent(equalTo(31), equalTo(2))));
+  }
+
+  @Test
+  public void listMapListenerOrderOnSourceAdd1() {
+    final boolean[] sourceFired = {false};
+    final boolean[] targetFired = {false};
+
+    source.addListener(new CollectionAdapter<Double>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Double> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(false));
+        sourceFired[0] = true;
+      }
+    });
+    target.addListener(new CollectionAdapter<Integer>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+        assertThat(sourceFired[0], is(true));
+        assertThat(targetFired[0], is(false));
+        targetFired[0] = true;
+      }
+    });
+    source.add(0, 0.0);
+    assertThat(sourceFired[0], is(true));
+    assertThat(targetFired[0], is(true));
+  }
+
+  @Test
+  public void listMapListenerOrderOnSourceAdd2() {
+    final boolean[] sourceFired = {false};
+    final boolean[] targetFired = {false};
+
+    target.addListener(new CollectionAdapter<Integer>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(false));
+        targetFired[0] = true;
+      }
+    });
+    source.addListener(new CollectionAdapter<Double>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Double> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(true));
+        sourceFired[0] = true;
+      }
+    });
+    source.add(0, 0.0);
+    assertThat(sourceFired[0], is(true));
+    assertThat(targetFired[0], is(true));
+  }
+
+  @Test
+  public void listMapListenerOrderOnTargetAdd1() {
+    final boolean[] sourceFired = {false};
+    final boolean[] targetFired = {false};
+
+    source.addListener(new CollectionAdapter<Double>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Double> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(false));
+        sourceFired[0] = true;
+      }
+    });
+    target.addListener(new CollectionAdapter<Integer>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+        assertThat(sourceFired[0], is(true));
+        assertThat(targetFired[0], is(false));
+        targetFired[0] = true;
+      }
+    });
+    target.add(0, 0);
+    assertThat(sourceFired[0], is(true));
+    assertThat(targetFired[0], is(true));
+  }
+
+  @Test
+  public void listMapListenerOrderOnTargetAdd2() {
+    final boolean[] sourceFired = {false};
+    final boolean[] targetFired = {false};
+
+    target.addListener(new CollectionAdapter<Integer>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(false));
+        targetFired[0] = true;
+      }
+    });
+    source.addListener(new CollectionAdapter<Double>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Double> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(true));
+        sourceFired[0] = true;
+      }
+    });
+    target.add(0, 0);
+    assertThat(sourceFired[0], is(true));
+    assertThat(targetFired[0], is(true));
+  }
+}

--- a/model/src/test/java/jetbrains/jetpad/model/collections/wrappers/ObservableSetWrapperTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/collections/wrappers/ObservableSetWrapperTest.java
@@ -1,0 +1,215 @@
+package jetbrains.jetpad.model.collections.wrappers;
+
+import jetbrains.jetpad.base.function.Function;
+import jetbrains.jetpad.model.collections.CollectionAdapter;
+import jetbrains.jetpad.model.collections.CollectionItemEvent;
+import jetbrains.jetpad.model.collections.CollectionListener;
+import jetbrains.jetpad.model.collections.set.ObservableHashSet;
+import jetbrains.jetpad.model.collections.set.ObservableSet;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static jetbrains.jetpad.model.collections.ObservableItemEventMatchers.addEvent;
+import static jetbrains.jetpad.model.collections.ObservableItemEventMatchers.removeEvent;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+public class ObservableSetWrapperTest {
+  private ObservableSet<Double> source = new ObservableHashSet<>();
+  private Function<Double, Integer> toTarget = new Function<Double, Integer>() {
+    @Override
+    public Integer apply(Double value) {
+      return value.intValue() + 1;
+    }
+  };
+  private Function<Integer, Double> toSource = new Function<Integer, Double>() {
+    @Override
+    public Double apply(Integer value) {
+      return Integer.valueOf(value - 1).doubleValue();
+    }
+  };
+  private ObservableSet<Integer> target = new ObservableSetWrapper<>(source, toTarget, toSource);
+
+  private List<CollectionItemEvent<?extends Integer>> addEvents = new ArrayList<>();
+  private List<CollectionItemEvent<?extends Integer>> setEvents = new ArrayList<>();
+  private List<CollectionItemEvent<?extends Integer>> removeEvents = new ArrayList<>();
+  private CollectionListener<Integer> listener = new CollectionListener<Integer>() {
+    @Override
+    public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+      addEvents.add(event);
+    }
+
+    @Override
+    public void onItemSet(CollectionItemEvent<? extends Integer> event) {
+      setEvents.add(event);
+    }
+
+    @Override
+    public void onItemRemoved(CollectionItemEvent<? extends Integer> event) {
+      removeEvents.add(event);
+    }
+  };
+  private void assertEvents(int addCount, int removeCount) {
+    assertThat(addEvents,    hasSize(addCount));
+    assertThat(setEvents,    is(empty()));
+    assertThat(removeEvents, hasSize(removeCount));
+  }
+
+
+  @Before
+  public void setup() {
+    source.addAll(Arrays.asList(10.0, 20.0, 30.0));
+    target.addListener(listener);
+  }
+
+  @Test
+  public void setMapMaps() {
+    assertThat(target, containsInAnyOrder(11, 21, 31));
+  }
+
+  @Test
+  public void setMapAddSource() {
+    source.add(15.0);
+    assertThat(target, containsInAnyOrder(11, 16, 21, 31));
+    assertEvents(1, 0);
+    assertThat(addEvents.get(0), is(addEvent(equalTo(16), equalTo(-1))));
+  }
+
+  @Test
+  public void listMapAddTarget() {
+    target.add(15);
+    assertThat(target, containsInAnyOrder(11, 15, 21, 31));
+    assertThat(source, containsInAnyOrder(10.0, 14.0, 20.0, 30.0));
+    assertEvents(1, 0);
+    assertThat(addEvents.get(0), is(addEvent(equalTo(15), equalTo(-1))));
+  }
+
+  @Test
+  public void setMapRemoveSource() {
+    source.remove(30.0);
+    assertThat(target, containsInAnyOrder(11, 21));
+    assertEvents(0, 1);
+    assertThat(removeEvents.get(0), is(removeEvent(equalTo(31), equalTo(-1))));
+  }
+
+  @Test
+  public void setMapRemoveTarget() {
+    target.remove(31);
+    assertThat(target, containsInAnyOrder(11, 21));
+    assertThat(source, containsInAnyOrder(10.0, 20.0));
+    assertEvents(0, 1);
+    assertThat(removeEvents.get(0), is(removeEvent(equalTo(31), equalTo(-1))));
+  }
+
+  @Test
+  public void setMapListenerOrderOnSourceAdd1() {
+    final boolean[] sourceFired = {false};
+    final boolean[] targetFired = {false};
+
+    source.addListener(new CollectionAdapter<Double>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Double> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(false));
+        sourceFired[0] = true;
+      }
+    });
+    target.addListener(new CollectionAdapter<Integer>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+        assertThat(sourceFired[0], is(true));
+        assertThat(targetFired[0], is(false));
+        targetFired[0] = true;
+      }
+    });
+    source.add(0.0);
+    assertThat(sourceFired[0], is(true));
+    assertThat(targetFired[0], is(true));
+  }
+
+  @Test
+  public void setMapListenerOrderOnSourceAdd2() {
+    final boolean[] sourceFired = {false};
+    final boolean[] targetFired = {false};
+
+    target.addListener(new CollectionAdapter<Integer>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(false));
+        targetFired[0] = true;
+      }
+    });
+    source.addListener(new CollectionAdapter<Double>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Double> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(true));
+        sourceFired[0] = true;
+      }
+    });
+    source.add(0.0);
+    assertThat(sourceFired[0], is(true));
+    assertThat(targetFired[0], is(true));
+  }
+
+  @Test
+  public void setMapListenerOrderOnTargetAdd1() {
+    final boolean[] sourceFired = {false};
+    final boolean[] targetFired = {false};
+
+    source.addListener(new CollectionAdapter<Double>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Double> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(false));
+        sourceFired[0] = true;
+      }
+    });
+    target.addListener(new CollectionAdapter<Integer>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+        assertThat(sourceFired[0], is(true));
+        assertThat(targetFired[0], is(false));
+        targetFired[0] = true;
+      }
+    });
+    target.add(0);
+    assertThat(sourceFired[0], is(true));
+    assertThat(targetFired[0], is(true));
+  }
+
+  @Test
+  public void setMapListenerOrderOnTargetAdd2() {
+    final boolean[] sourceFired = {false};
+    final boolean[] targetFired = {false};
+
+    target.addListener(new CollectionAdapter<Integer>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Integer> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(false));
+        targetFired[0] = true;
+      }
+    });
+    source.addListener(new CollectionAdapter<Double>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Double> event) {
+        assertThat(sourceFired[0], is(false));
+        assertThat(targetFired[0], is(true));
+        sourceFired[0] = true;
+      }
+    });
+    target.add(0);
+    assertThat(sourceFired[0], is(true));
+    assertThat(targetFired[0], is(true));
+  }
+}


### PR DESCRIPTION
This is a replacement for #144 with tests added.

I hope it is not a problem that I added a dependency on `org.hamcrest.hamcrest-library` as writing tests without hamcrest matchers would have been very burdensome.