### PR TITLE
edt.resetOwner()

### DIFF
--- a/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEventDispatchThread.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEventDispatchThread.java
@@ -31,18 +31,20 @@ public final class TestEventDispatchThread implements EventDispatchThread {
   private boolean myFinished = false;
   private boolean myRunning = false;
 
+  private Thread myOwner;
+
   public TestEventDispatchThread() {
     this("");
   }
 
   public TestEventDispatchThread(String name) {
-    final Thread owner = Thread.currentThread();
+    resetOwner();
     myThreadSafeChecker = new Runnable() {
       @Override
       public void run() {
         Thread current = Thread.currentThread();
-        if (owner != current) {
-          throw new IllegalStateException("Test EDT is not thread-safe. Owner is " + owner + ". Attempt to access from " + current);
+        if (myOwner != current) {
+          throw new IllegalStateException("Test EDT is not thread-safe. Owner is " + myOwner + ". Attempt to access from " + current);
         }
       }
     };
@@ -64,6 +66,10 @@ public final class TestEventDispatchThread implements EventDispatchThread {
 
   public int size() {
     return myRecords.size();
+  }
+
+  public void resetOwner() {
+    myOwner = Thread.currentThread();
   }
 
   public boolean nothingScheduled(int time) {

--- a/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEventDispatchThreadTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/edt/TestEventDispatchThreadTest.java
@@ -15,6 +15,7 @@
  */
 package jetbrains.jetpad.base.edt;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -22,6 +23,11 @@ import static org.mockito.Mockito.times;
 
 public class TestEventDispatchThreadTest {
   private TestEventDispatchThread edt = new TestEventDispatchThread();
+
+  @Before
+  public void setUp() {
+    edt.resetOwner();
+  }
 
   @Test
   public void simpleInvokeLater() {

--- a/util/base/src/test/java/jetbrains/jetpad/base/edt/TimeoutEdtTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/edt/TimeoutEdtTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.base.edt;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.mockito.Mockito;
+
+public final class TimeoutEdtTest {
+
+  @Rule
+  public final Timeout testTimeout = new Timeout(10000);
+
+  private TestEventDispatchThread edt = new TestEventDispatchThread();
+
+  @Before
+  public void setUp() {
+    edt.resetOwner();
+  }
+
+  @Test
+  public void testInANewThread() {
+    Runnable r = Mockito.mock(Runnable.class);
+    edt.schedule(r);
+    edt.executeUpdates();
+    Mockito.verify(r).run();
+  }
+
+}


### PR DESCRIPTION
If each test is executed in a different thread (e.g. you use a org.junit.rules.Timeout rule), TestEventDispatchThread could throw an exception because the owner doesn't match the current thread.

For example, if you add `@Rule public final Timeout testTimeout = new Timeout(10000);`
to the old version of TestEventDispatchThreadTest, some tests will fail there with the above exception.

I encountered a similar situation when I need to reuse an instance of TestEventDispatchThread across different tests executed each in a separate thread because of the usage of the Timeout rule.