### PR TITLE
pass string and offsets to Json.unescape(), move this method call to JsonLexer

### DIFF
--- a/util/json/src/main/java/jetbrains/jetpad/json/DefautJsonSupport.java
+++ b/util/json/src/main/java/jetbrains/jetpad/json/DefautJsonSupport.java
@@ -26,9 +26,9 @@ public class DefautJsonSupport implements JsonSupport {
   private JsonValue parseValue(JsonLexer lexer) {
     switch (lexer.tokenKind()) {
       case STRING:
-        String sv = lexer.tokenText();
+        String sv = lexer.literalTokenText();
         lexer.next();
-        return new JsonString(getLiteralText(sv));
+        return new JsonString(sv);
       case LEFT_BRACKET:
         return parseArray(lexer);
       case NUMBER:
@@ -64,7 +64,7 @@ public class DefautJsonSupport implements JsonSupport {
       if (lexer.tokenKind() != JsonTokenKind.STRING) {
         throw new JsonParsingException();
       }
-      String key = getLiteralText(lexer.tokenText());
+      String key = lexer.literalTokenText();
       lexer.next();
 
       lexer.readToken(JsonTokenKind.COLON);
@@ -90,9 +90,5 @@ public class DefautJsonSupport implements JsonSupport {
 
     lexer.readToken(JsonTokenKind.RIGHT_BRACKET);
     return result;
-  }
-
-  static String getLiteralText(String literal) {
-    return JsonUtil.unescape(literal.substring(1, literal.length() - 1));
   }
 }

--- a/util/json/src/main/java/jetbrains/jetpad/json/InputStreamJsonLexer.java
+++ b/util/json/src/main/java/jetbrains/jetpad/json/InputStreamJsonLexer.java
@@ -44,6 +44,12 @@ class InputStreamJsonLexer extends JsonLexer {
   }
 
   @Override
+  protected String literalTokenText() {
+    String tokenText = tokenText();
+    return JsonUtil.unescape(tokenText, 1, tokenText.length());
+  }
+
+  @Override
   protected void setTokenStart() {
     myTokenString.delete(0, myTokenString.length());
   }

--- a/util/json/src/main/java/jetbrains/jetpad/json/JsonLexer.java
+++ b/util/json/src/main/java/jetbrains/jetpad/json/JsonLexer.java
@@ -27,6 +27,8 @@ abstract class JsonLexer {
 
   protected abstract String tokenText();
 
+  protected abstract String literalTokenText();
+
   JsonTokenKind tokenKind() {
     if (myDeferred) {
       myDeferred = false;

--- a/util/json/src/main/java/jetbrains/jetpad/json/JsonUtil.java
+++ b/util/json/src/main/java/jetbrains/jetpad/json/JsonUtil.java
@@ -83,15 +83,14 @@ class JsonUtil {
     return builder.toString();
   }
 
-  static String unescape(String s) {
+  static String unescape(String s, int start, int end) {
     StringBuilder result = null;
-    int len = s.length();
-    for (int i = 0; i < len; i++) {
+    for (int i = start; i < end; i++) {
       char ch = s.charAt(i);
-      if (ch == '\\' && i < len - 1) {
+      if (ch == '\\' && i < end - 1) {
         if (result == null) {
           result = new StringBuilder();
-          result.append(s.substring(0, i));
+          result.append(s.substring(start, i));
         }
 
         i++;
@@ -103,7 +102,7 @@ class JsonUtil {
         if (specialChar != -1) {
           result.append((char) specialChar);
         } else if (ch == 'u') {
-          if (i >= len - 4) {
+          if (i >= end - 4) {
             throw new RuntimeException();
           }
           String hexNumber = s.substring(i + 1, i + 5);
@@ -122,7 +121,7 @@ class JsonUtil {
     if (result != null) {
       return result.toString();
     } else {
-      return s;
+      return s.substring(start, end);
     }
   }
 

--- a/util/json/src/main/java/jetbrains/jetpad/json/StringJsonLexer.java
+++ b/util/json/src/main/java/jetbrains/jetpad/json/StringJsonLexer.java
@@ -43,6 +43,11 @@ class StringJsonLexer extends JsonLexer {
     return myInput.substring(myTokenStart, myPosition);
   }
 
+  @Override
+  protected String literalTokenText() {
+    return JsonUtil.unescape(myInput, myTokenStart + 1, myPosition - 1);
+  }
+
   protected void setTokenStart() {
     myTokenStart = myPosition;
   }


### PR DESCRIPTION
In the current code we call substring() in StringJsonLexer.tokenText() and DefaultJsonSupport. getLiteralText() methods for each string literal. In this change I get rid of both calls.
The number of allocated strings reduced from 718k to 464k on my test witch parse 9mb string.    