### PR TITLE
Add parallelResult async method

### DIFF
--- a/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
@@ -213,6 +213,27 @@ public class Asyncs {
     return parallel(asyncs, false, new ThreadSafeParallelData(asyncs.size()));
   }
 
+  @GwtIncompatible
+  public static <ItemT> Async<List<ItemT>> parallelResult(Collection<Async<ItemT>> asyncs) {
+    final List<ItemT> result = Collections.synchronizedList(new ArrayList<ItemT>());
+
+    for (Async<ItemT> async : asyncs) {
+      async.onSuccess(
+          new Consumer<ItemT>() {
+            @Override
+            public void accept(ItemT item) {
+              result.add(item);
+            }
+          }
+      );
+    }
+
+    return seq(
+        parallel(asyncs, true, new ThreadSafeParallelData(asyncs.size())),
+        Asyncs.constant(result)
+    );
+  }
+
   private static Async<Void> parallel(Collection<? extends Async<?>> asyncs, final boolean alwaysSucceed,
       final ParallelData parallelData) {
     if (asyncs.isEmpty()) {

--- a/util/base/src/test/java/jetbrains/jetpad/base/AsyncsTest.java
+++ b/util/base/src/test/java/jetbrains/jetpad/base/AsyncsTest.java
@@ -206,6 +206,16 @@ public class AsyncsTest {
   }
 
   @Test
+  public void parallelResult() {
+    assertThat(
+        Asyncs.parallelResult(Arrays.asList(
+            Asyncs.constant(1), Asyncs.<Integer>failure(new Throwable()), Asyncs.constant(2)
+        )),
+        result(equalTo(Arrays.asList(1, 2)))
+    );
+  }
+
+  @Test
   public void untilSuccess() {
     assertThat(
         Asyncs.untilSuccess(new Supplier<Async<Integer>>() {


### PR DESCRIPTION
A new async method that resolves a collection of asyncs, ignoring any failures and returning a list of succeeded items.