### PR TITLE
Synchronizers.forDisposable()

### DIFF
--- a/mapper/src/main/java/jetbrains/jetpad/mapper/Synchronizers.java
+++ b/mapper/src/main/java/jetbrains/jetpad/mapper/Synchronizers.java
@@ -15,7 +15,10 @@
  */
 package jetbrains.jetpad.mapper;
 
+import jetbrains.jetpad.base.Disposable;
 import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.base.function.Consumer;
+import jetbrains.jetpad.base.function.Supplier;
 import jetbrains.jetpad.model.collections.CollectionAdapter;
 import jetbrains.jetpad.model.collections.CollectionItemEvent;
 import jetbrains.jetpad.model.collections.ObservableCollection;
@@ -30,8 +33,6 @@ import jetbrains.jetpad.model.property.WritableProperty;
 import jetbrains.jetpad.model.transform.Transformer;
 
 import java.util.List;
-import jetbrains.jetpad.base.function.Consumer;
-import jetbrains.jetpad.base.function.Supplier;
 import java.util.logging.Logger;
 
 /**
@@ -204,6 +205,32 @@ public class Synchronizers {
       @Override
       public void detach() {
         r.remove();
+      }
+    };
+  }
+
+  public static Synchronizer forDisposable(final Disposable disposable) {
+    return new Synchronizer() {
+      @Override
+      public void attach(SynchronizerContext ctx) {}
+
+      @Override
+      public void detach() {
+        disposable.dispose();
+      }
+    };
+  }
+
+  public static Synchronizer forDisposables(final Disposable... disposables) {
+    return new Synchronizer() {
+      @Override
+      public void attach(SynchronizerContext ctx) {}
+
+      @Override
+      public void detach() {
+        for (Disposable disposable : disposables) {
+          disposable.dispose();
+        }
       }
     };
   }

--- a/mapper/src/test/java/jetbrains/jetpad/mapper/ForDisposableTest.java
+++ b/mapper/src/test/java/jetbrains/jetpad/mapper/ForDisposableTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2017 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.mapper;
+
+import jetbrains.jetpad.base.Disposable;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public final class ForDisposableTest {
+
+  private final DisposableObject myDisposable1 = new DisposableObject();
+  private final DisposableObject myDisposable2 = new DisposableObject();
+
+  @Test
+  public void forDisposable() {
+    Synchronizer synchronizer = Synchronizers.forDisposable(myDisposable1);
+    synchronizer.detach();
+    myDisposable1.assertDisposed();
+  }
+
+  @Test
+  public void forDisposables() {
+    Synchronizer synchronizer = Synchronizers.forDisposables(myDisposable1, myDisposable2);
+    synchronizer.detach();
+    myDisposable1.assertDisposed();
+    myDisposable2.assertDisposed();
+  }
+
+  private static final class DisposableObject implements Disposable {
+
+    private boolean isDisposed;
+
+    private DisposableObject() {
+    }
+
+    @Override
+    public void dispose() {
+      isDisposed = true;
+    }
+
+    private void assertDisposed() {
+      assertTrue(isDisposed);
+    }
+
+  }
+
+}


### PR DESCRIPTION
These two methods can be used instead of:
Synchronizers.forRegistration(Registration.from(...)
