### PR TITLE
switch to Guava iterator implementation for preOrderTraversal

### DIFF
--- a/model/src/main/java/jetbrains/jetpad/model/composite/Composites.java
+++ b/model/src/main/java/jetbrains/jetpad/model/composite/Composites.java
@@ -15,10 +15,12 @@
  */
 package jetbrains.jetpad.model.composite;
 
+import com.google.common.collect.TreeTraverser;
 import jetbrains.jetpad.base.function.Function;
 import jetbrains.jetpad.base.function.Predicate;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -579,17 +581,13 @@ public final class Composites {
     return ourWithBounds.lowerFocusable(v, xOffset);
   }
 
-  public static <CompositeT extends Composite<CompositeT>> Iterable<CompositeT> iterateBranch(CompositeT branch) {
-    List<CompositeT> list = new ArrayList<>();
-    addBranch(branch, list);
-    return list;
-  }
-
-  private static <CompositeT extends Composite<CompositeT>> void addBranch(CompositeT branch, List<CompositeT> accum) {
-    accum.add(branch);
-    for (CompositeT c : branch.children()) {
-      addBranch(c, accum);
-    }
+  public static <CompositeT extends Composite<CompositeT>> Iterable<CompositeT> preOrderTraversal(CompositeT root) {
+    return TreeTraverser.using(new com.google.common.base.Function<CompositeT, Iterable<CompositeT>>() {
+      @Override
+      public Iterable<CompositeT> apply(CompositeT input) {
+        return input == null ? Collections.<CompositeT>emptyList() : input.children();
+      }
+    }).preOrderTraversal(root);
   }
 
   private Composites() {

--- a/model/src/test/java/jetbrains/jetpad/model/composite/CompositesTest.java
+++ b/model/src/test/java/jetbrains/jetpad/model/composite/CompositesTest.java
@@ -15,14 +15,13 @@
  */
 package jetbrains.jetpad.model.composite;
 
+import com.google.common.collect.Lists;
 import jetbrains.jetpad.base.function.Predicate;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import static jetbrains.jetpad.model.composite.TestComposite.create;
 import static org.junit.Assert.assertEquals;
@@ -107,12 +106,12 @@ public class CompositesTest {
 
   @Test
   public void nextLeaves() {
-    assertEquals(Arrays.asList(leaf12, leaf21, leaf22), asList(Composites.nextLeaves(leaf11)));
+    assertEquals(Arrays.asList(leaf12, leaf21, leaf22), Lists.newArrayList(Composites.nextLeaves(leaf11)));
   }
 
   @Test
   public void prevLeaves() {
-    assertEquals(Arrays.asList(leaf12, leaf11), asList(Composites.prevLeaves(leaf21)));
+    assertEquals(Arrays.asList(leaf12, leaf11), Lists.newArrayList(Composites.prevLeaves(leaf21)));
   }
 
   @Test
@@ -415,15 +414,7 @@ public class CompositesTest {
   @Test
   public void iterateBranch() {
     assertEquals(Arrays.asList(root, child1, leaf11, leaf12, child2, leaf21, leaf22),
-      Composites.iterateBranch(root));
-  }
-
-  private List<TestComposite> asList(Iterable<TestComposite> it) {
-    List<TestComposite> result = new ArrayList<>();
-    for (TestComposite v : it) {
-      result.add(v);
-    }
-    return result;
+        Lists.newArrayList(Composites.preOrderTraversal(root)));
   }
 
 }


### PR DESCRIPTION
Also rename method `iterateBranch` to more well-known `preOrderTraversal` to let developers find it somehow.