### PR TITLE
Inefficient Usage of Java Collections

### DIFF
--- a/model/src/main/java/jetbrains/jetpad/model/composite/Composites.java
+++ b/model/src/main/java/jetbrains/jetpad/model/composite/Composites.java
@@ -21,6 +21,7 @@ import jetbrains.jetpad.base.function.Function;
 import jetbrains.jetpad.base.function.Predicate;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -374,7 +375,7 @@ public final class Composites {
   }
 
   static <ItemT> List<ItemT> toList(Iterable<ItemT> it) {
-    List<ItemT> result = new ArrayList<>();
+    List<ItemT> result = new LinkedList<>();
     for (ItemT i : it) {
       result.add(i);
     }

--- a/model/src/main/java/jetbrains/jetpad/model/composite/TreePath.java
+++ b/model/src/main/java/jetbrains/jetpad/model/composite/TreePath.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.model.composite;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -53,7 +54,7 @@ public class TreePath<CompositeT extends Composite<CompositeT>> implements Compa
     return new TreePath<>(path);
   }
 
-  private List<Integer> myPath = new ArrayList<>();
+  private List<Integer> myPath = new LinkedList<>();
 
   public TreePath(CompositeT composite) {
     this(composite, null);

--- a/model/src/main/java/jetbrains/jetpad/model/composite/TreePath.java
+++ b/model/src/main/java/jetbrains/jetpad/model/composite/TreePath.java
@@ -115,7 +115,7 @@ public class TreePath<CompositeT extends Composite<CompositeT>> implements Compa
     if (myPath.isEmpty()) {
       throw new IllegalStateException();
     }
-    return myPath.get(myPath.size() - 1);
+    return myPath.getLast();
   }
 
   public TreePath<CompositeT> getParent() {
@@ -123,7 +123,8 @@ public class TreePath<CompositeT extends Composite<CompositeT>> implements Compa
       throw new IllegalStateException();
     }
 
-    return new TreePath<>(myPath.subList(0, myPath.size() - 1));
+    ArrayList<Integer> treePathList = new ArrayList<>(myPath);
+    return new TreePath<>(treePathList.subList(0, treePathList.size() - 1));
   }
 
   public TreePath<CompositeT> getChild(int index) {

--- a/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/Asyncs.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -280,7 +281,7 @@ public final class Asyncs {
 
   public static <ItemT> Async<List<ItemT>> composite(List<Async<ItemT>> asyncs) {
     final SimpleAsync<List<ItemT>> result = new SimpleAsync<>();
-    final SortedMap<Integer, ItemT> succeeded = new TreeMap<>();
+    final HashMap<Integer, ItemT> succeeded = new HashMap<>();
     final List<Throwable> exceptions = new ArrayList<>(0);
     final Value<Integer> inProgress = new Value<>(asyncs.size());
 

--- a/util/base/src/main/java/jetbrains/jetpad/base/ThrowableHandlers.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/ThrowableHandlers.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -186,7 +187,7 @@ public final class ThrowableHandlers {
   }
 
   private static class MyEventSource {
-    private final List<Consumer<? super Throwable>> myHandlers = new ArrayList<>();
+    private final List<Consumer<? super Throwable>> myHandlers = new LinkedList<>();
 
     void fire(Throwable throwable) {
       for (Consumer<? super Throwable> handler : new ArrayList<>(myHandlers)) {

--- a/util/base/src/main/java/jetbrains/jetpad/base/diff/DifferenceBuilder.java
+++ b/util/base/src/main/java/jetbrains/jetpad/base/diff/DifferenceBuilder.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.base.diff;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 public final class DifferenceBuilder<ItemT> {
@@ -28,7 +29,7 @@ public final class DifferenceBuilder<ItemT> {
   }
 
   public List<DifferenceItem> build() {
-    List<DifferenceItem> result = new ArrayList<>();
+    List<DifferenceItem> result = new LinkedList<>();
 
     List<ItemT> sourceContent = mySourceList;
     List<ItemT> target = new ArrayList<>(myTargetList);

--- a/util/geometry/src/main/java/jetbrains/jetpad/geometry/DoubleRectangle.java
+++ b/util/geometry/src/main/java/jetbrains/jetpad/geometry/DoubleRectangle.java
@@ -18,6 +18,7 @@ package jetbrains.jetpad.geometry;
 import com.google.common.collect.Range;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 public class DoubleRectangle {
@@ -137,7 +138,7 @@ public class DoubleRectangle {
   }
 
   public Iterable<DoubleSegment> getParts() {
-    List<DoubleSegment> result = new ArrayList<>();
+    List<DoubleSegment> result = new LinkedList<>();
     result.add(new DoubleSegment(origin, origin.add(new DoubleVector(dimension.x, 0))));
     result.add(new DoubleSegment(origin, origin.add(new DoubleVector(0, dimension.y))));
     result.add(new DoubleSegment(origin.add(dimension), origin.add(new DoubleVector(dimension.x, 0))));


### PR DESCRIPTION
Hi,
We find that there are several ArrayList objects which are not manipulated by random access. Due to the memory reallocation triggered in the successive insertions, the time complexity of add method of ArrayList is amortized O(1). We notice that these objects are only used for traversal, the retrieval, and removal of the first or the last element.

This functionality can be implemented by LinkedList. Moreover, the insertion of LinkedList is strictly O(1) time complexity because no memory reallocation occurs.

Meanwhile, we also found several TreeMap objects which are not necessary to maintain the key order relation. To achieve the same functionality, HashHap is enough. The replacement can also reduce the time cost in the modification of the map objects.

We discovered the above inefficient usage of containers by our tool Ditto. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

Bests

Ditto